### PR TITLE
Clean up to improve readability.

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -104,7 +104,8 @@ int parse_cpu_list(char *cpu_list, cpu_set_t *cpu_set) {
   while ((range = strsep(&string, ",")) != NULL) {
     int first = strtol(range, &endptr, CPU_LIST_BASE);
     /*
-     * When there is no endptr this is a single cpu in the cpu list, not a range.
+     * When there is no endptr this is a single cpu in the cpu list, not a
+     * range.
      */
     if (!*endptr) {
       CPU_SET(first, cpu_set);
@@ -115,9 +116,12 @@ int parse_cpu_list(char *cpu_list, cpu_set_t *cpu_set) {
     int last = strtol(endptr, &endptr, CPU_LIST_BASE);
     /*
      * Here we check the following.
-     *   1. Ensure save[0] (endptr from the strtol() operation to find first) contains our range delimiter, '-'.
-     *   2. Ensure endptr (endptr from the strtol() operation to find last) is NULL.
-     *   3. Ensure that last is not less than first (procfs accepts ranges where last equals first, so we will too).
+     *   1. Ensure save[0] (endptr from the strtol() operation to find first)
+     *      contains our range delimiter, '-'.
+     *   2. Ensure endptr (endptr from the strtol() operation to find last) is
+     *      NULL.
+     *   3. Ensure that last is not less than first (procfs accepts ranges where
+     *      last equals first, so we will too).
      */
     if (save[0] != '-' || *endptr || last < first) {
       return RETURN_BAD;

--- a/interface.c
+++ b/interface.c
@@ -26,5 +26,11 @@ int interface_set_promisc_on(const unsigned int ifindex) {
     return -1;
   }
 
-  return setsockopt(fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, (void *)&mr, sizeof(mr));
+  return setsockopt(
+           fd,
+           SOL_PACKET,
+           PACKET_ADD_MEMBERSHIP,
+           (void *)&mr,
+           sizeof(mr)
+         );
 }

--- a/main.c
+++ b/main.c
@@ -246,7 +246,7 @@ int main(int argc, char **argv) {
         free(badopt);
         usage_short();
         return EXIT_FAIL_OPTION;
-      }
+    }
   }
 
   if (help) {

--- a/main.c
+++ b/main.c
@@ -100,22 +100,13 @@ int main(int argc, char **argv) {
 
   args.program_fullname = argv[0];
   args.program_basename = program_basename;
-  args.packet_count     = 0;
-  args.capture_rx       = true;
-  args.capture_tx       = true;
-  args.packet_buffered  = false;
-  args.promiscuous      = false;
-  args.verbose          = false;
-
-  char *cpu_list = NULL;
-  char *cpu_mask = NULL;
-  bool help = false;
-  int worker_count;
-  cpu_set_t online_cpu_set;
 
   /*
    * capture_rx and capture_tx defaults are based on the invocation.
    */
+  args.capture_rx = true;
+  args.capture_tx = true;
+
   if (strcmp(program_basename, "rxcpu") == 0) {
     args.capture_tx = false;
   }
@@ -125,8 +116,12 @@ int main(int argc, char **argv) {
   }
 
   int c;
-  char *badopt;
-  char *endptr;
+  char *badopt = NULL;
+  char *cpu_list = NULL;
+  char *cpu_mask = NULL;
+  char *endptr = NULL;
+  bool help = false;
+
   /*
    * optstring must start with ":" so ':' is returned for a missing option
    * argument. Otherwise '?' is returned for both invalid option and missing
@@ -284,7 +279,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  worker_count = 0;
+  int worker_count = 0;
   for (int i = 0; i < args.processor_count; i++) {
     if (CPU_ISSET(i, &(args.capture_cpu_set))) {
       worker_count++;
@@ -301,6 +296,7 @@ int main(int argc, char **argv) {
     return EXIT_FAIL_OPTION;
   }
 
+  cpu_set_t online_cpu_set;
   if (get_online_cpu_set(&online_cpu_set) != 0) {
     fprintf(stderr, "%s: Failed to get online cpu set.\n", program_basename);
     return EXIT_FAIL_OPTION;

--- a/sig.c
+++ b/sig.c
@@ -10,7 +10,7 @@
 
 #include "sig.h"
 
-#include <signal.h> // for sigaction, sigaction(), sigfillset()
+#include <signal.h> // for sigaction, sigaction(), SIGINT, sigfillset()
 #include <stdio.h>  // for fprintf()
 #include <unistd.h> // for STDERR_FILENO, write()
 
@@ -40,7 +40,11 @@ int setup_signals(void) {
   sigfillset(&sa.sa_mask);
 
   if (sigaction(SIGINT, &sa, NULL) == -1) {
-    fprintf(stderr, "%s: Failed to setup signal handler for SIGINT.\n", program_basename);
+    fprintf(
+      stderr,
+      "%s: Failed to setup signal handler for SIGINT.\n",
+      program_basename
+    );
     return -1;
   }
 


### PR DESCRIPTION
Various clean up to improve readability.
* reorganize some declarations (group similar, move closer to related operations)
* fix some pointer initializations
* remove some redundant assignments to struct members already initialized via memset()
* fix misaligned curly brace
* reformat lines which exceed 80 characters
* fix signal.h comment in sig.h