### PR TITLE
Fix exit code for sysconf(_SC_NPROCESSORS_CONF) failure.

### DIFF
--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -266,7 +266,7 @@ int main(int argc, char **argv) {
   args.processor_count = sysconf(_SC_NPROCESSORS_CONF);
   if (args.processor_count <= 0) {
     fprintf(stderr, "%s: Failed to get processor count.\n", program_basename);
-    return EXIT_FAIL_OPTION;
+    return EXIT_FAIL;
   }
 
   if (args.verbose) {


### PR DESCRIPTION
This is not caused by bad command line options. We should be using EXIT_FAIL, not EXIT_FAIL_OPTION.