### PR TITLE
free() badopt only when malloc() was actually called.

### DIFF
--- a/features/cli.feature
+++ b/features/cli.feature
@@ -56,6 +56,13 @@ Feature: Cli
     And the stderr should contain "rxtxcpu: Unrecognized option '-z'."
     And the stderr should contain "Usage: rxtxcpu [--help]"
 
+  Scenario: unrecognized long argument
+    When I run `./rxtxcpu --zzz`
+    Then the exit status should be 2
+    And the stdout should not contain anything
+    And the stderr should contain "rxtxcpu: Unrecognized option '--zzz'."
+    And the stderr should contain "Usage: rxtxcpu [--help]"
+
   Scenario: cpu list and cpu mask
     When I run `./rxtxcpu -l0 -m1`
     Then the exit status should be 2

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -263,7 +263,9 @@ int main(int argc, char **argv) {
           badopt = argv[optind-1];
         }
         fprintf(stderr, "%s: Unrecognized option '%s'.\n", program_basename, badopt);
-        free(badopt);
+        if (optopt) {
+          free(badopt);
+        }
         usage_short();
         return EXIT_FAIL_OPTION;
     }


### PR DESCRIPTION
Attempting to `free(badopt);` when `badopt = argv[optind-1];` does bad things. This change fixes things so that `free()` is called only when `malloc()` has been called. It also adds a test case for unrecognized long arguments to prevent regression.