### PR TITLE
More provisioner improvements.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 rxcpu
 rxtxcpu
 txcpu
+/helpers/tap-mq-pong
 
 # Debug files
 *.dSYM/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
 
-  config.vm.define "seven-ml", autostart: false do |_self|
+  config.vm.define "seven-ml", primary: true do |_self|
     _self.vm.box = "centos/7"
     _self.vm.provider "virtualbox" do |v|
       v.memory = 4096
@@ -14,7 +14,7 @@ Vagrant.configure("2") do |config|
     _self.vbguest.auto_update = false
   end
 
-  config.vm.define "seven", primary: true do |_self|
+  config.vm.define "seven", autostart: false do |_self|
     _self.vm.box = "centos/7"
     _self.vm.provider "virtualbox" do |v|
       v.memory = 4096

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,6 +10,7 @@ Vagrant.configure("2") do |config|
     _self.vm.provision "shell", path: "provisioners/centos/kernel-ml.sh"
     _self.vm.provision :reload
     _self.vm.provision "shell", path: "provisioners/netmap.sh"
+    _self.vm.provision "shell", path: "provisioners/centos/kernel-ml-rebuild-tun.sh"
     _self.vm.synced_folder ".", "/vagrant", type: "rsync"
     _self.vbguest.auto_update = false
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure("2") do |config|
     _self.vm.provision "shell", path: "provisioners/centos/requires.sh"
     _self.vm.provision "shell", path: "provisioners/centos/kernel-ml.sh"
     _self.vm.provision :reload
+    _self.vm.provision "shell", path: "provisioners/netmap.sh"
     _self.vm.synced_folder ".", "/vagrant", type: "rsync"
     _self.vbguest.auto_update = false
   end
@@ -20,6 +21,7 @@ Vagrant.configure("2") do |config|
       v.cpus = 2
     end
     _self.vm.provision "shell", path: "provisioners/centos/requires.sh"
+    _self.vm.provision "shell", path: "provisioners/netmap.sh"
     _self.vm.synced_folder ".", "/vagrant", type: "virtualbox"
   end
 
@@ -30,6 +32,7 @@ Vagrant.configure("2") do |config|
       v.cpus = 2
     end
     _self.vm.provision "shell", path: "provisioners/ubuntu/requires.sh"
+    _self.vm.provision "shell", path: "provisioners/netmap.sh"
     _self.vm.synced_folder ".", "/vagrant", type: "rsync"
     _self.vbguest.auto_update = false
   end
@@ -41,6 +44,7 @@ Vagrant.configure("2") do |config|
       v.cpus = 2
     end
     _self.vm.provision "shell", path: "provisioners/ubuntu/requires.sh"
+    _self.vm.provision "shell", path: "provisioners/netmap.sh"
     _self.vm.synced_folder ".", "/vagrant", type: "rsync"
     _self.vbguest.auto_update = false
   end
@@ -52,6 +56,7 @@ Vagrant.configure("2") do |config|
       v.cpus = 2
     end
     _self.vm.provision "shell", path: "provisioners/ubuntu/requires.sh"
+    _self.vm.provision "shell", path: "provisioners/netmap.sh"
     _self.vm.synced_folder ".", "/vagrant", type: "rsync"
     _self.vbguest.auto_update = false
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure("2") do |config|
     _self.vm.provision :reload
     _self.vm.provision "shell", path: "provisioners/netmap.sh"
     _self.vm.provision "shell", path: "provisioners/centos/kernel-ml-rebuild-tun.sh"
+    _self.vm.provision "shell", path: "provisioners/centos/tap0.sh"
     _self.vm.synced_folder ".", "/vagrant", type: "rsync"
     _self.vbguest.auto_update = false
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -22,7 +22,8 @@ Vagrant.configure("2") do |config|
     end
     _self.vm.provision "shell", path: "provisioners/centos/requires.sh"
     _self.vm.provision "shell", path: "provisioners/netmap.sh"
-    _self.vm.synced_folder ".", "/vagrant", type: "virtualbox"
+    _self.vm.synced_folder ".", "/vagrant", type: "rsync"
+    _self.vbguest.auto_update = false
   end
 
   config.vm.define "trusty", autostart: false do |_self|

--- a/features/offline.feature
+++ b/features/offline.feature
@@ -4,8 +4,8 @@ Feature: offline cpu
   not available on ubuntu. `/sys/devices/system/node/node*/cpu*/online` is
   available in all our current test environments. We'll use that.
 
-  cpu0 is not hot pluggable in ubuntu, so certain tests are marked with the
-  ExlcudeFromUbuntu tag.
+  cpu0 is not hot pluggable in some of our environments, so certain tests are
+  marked with the RequireHotplugCpu0 tag.
 
   Scenario: Packets sent on cpu0 are counted as such when cpu1 is offline
     Given I wait 2 seconds for a command to start up
@@ -21,7 +21,7 @@ Feature: offline cpu
     # The following is equivalent to `sudo chcpu -e 1`
     And I run `bash -c 'echo 1 | sudo tee /sys/devices/system/node/node0/cpu1/online'`
 
-  @ExcludeFromUbuntu
+  @RequireHotplugCpu0
   Scenario: Packets sent on cpu1 are counted as such when cpu0 is offline
     Given I wait 2 seconds for a command to start up
     # The following is equivalent to `sudo chcpu -d 0`
@@ -51,7 +51,7 @@ Feature: offline cpu
     12 packets captured total.
     """
 
-  @ExcludeFromUbuntu
+  @RequireHotplugCpu0
   Scenario: Packets sent on cpu1 are counted as such when cpu0 is offline and flipped online
     Given I wait 2 seconds for a command to start up
     # The following is equivalent to `sudo chcpu -d 0`
@@ -67,7 +67,7 @@ Feature: offline cpu
     12 packets captured total.
     """
 
-  @ExcludeFromUbuntu
+  @RequireHotplugCpu0
   Scenario: Packets sent on cpu0 are counted as such when processed before cpu0 is flipped offline
     Given I wait 2 seconds for a command to start up
     When I run `sudo timeout -s INT 10 ../../rxtxcpu lo` in background

--- a/helpers/Makefile
+++ b/helpers/Makefile
@@ -1,0 +1,56 @@
+CC = gcc
+CFLAGS = -Wall -Wcast-align -Wcast-qual -Wimplicit -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow
+
+ifndef PREFIX
+PREFIX = /usr
+endif
+
+ifndef SBINDIR
+SBINDIR = $(PREFIX)/sbin
+endif
+
+ifndef BINDIR
+BINDIR = $(PREFIX)/bin
+endif
+
+ifndef SYSCONFDIR
+SYSCONFDIR = /etc
+endif
+
+ifndef UNITDIR
+UNITDIR = $(PREFIX)/lib/systemd/system
+endif
+
+tap-mq-pong: tap_mq_pong.c
+	$(CC) $(CFLAGS) -std=c99 -D_POSIX_C_SOURCE=200809L -o $@ $^ -lpthread
+
+.PHONY: clean
+clean:
+	rm -f tap-mq-pong
+
+.PHONY: install
+# This Makefile is tailored for our testing environment; this install target
+# is naive and may have undesirable results in other environments. Require
+# /vagrant/Vagrantfile as a simple guard to (hopefully) ensure we're in our
+# testing environment.
+install: /vagrant/Vagrantfile tap-mq-configure-packet-steering.sh tap-mq-destroy.sh tap-mq-init.sh tap-mq-pong tap-mq-pong@.service
+	mkdir -p $(DESTDIR)$(SBINDIR)
+	mkdir -p $(DESTDIR)$(UNITDIR)
+	mkdir -p $(DESTDIR)$(SYSCONFDIR)/sysconfig/tap-mq-pong/
+	install -m 755 tap-mq-configure-packet-steering.sh $(DESTDIR)$(SBINDIR)/tap-mq-configure-packet-steering
+	install -m 755 tap-mq-destroy.sh                   $(DESTDIR)$(SBINDIR)/tap-mq-destroy
+	install -m 755 tap-mq-init.sh                      $(DESTDIR)$(SBINDIR)/tap-mq-init
+	install -m 755 tap-mq-pong                         $(DESTDIR)$(BINDIR)/
+	install -m 644 tap-mq-pong@.service                $(DESTDIR)$(UNITDIR)/
+	systemctl daemon-reload
+
+.PHONY: uninstall
+# See /vagrant/Vagrantfile comment above install target; the same applies to
+# uninstall.
+uninstall: /vagrant/Vagrantfile
+	rm $(DESTDIR)$(SBINDIR)/tap-mq-configure-packet-steering
+	rm $(DESTDIR)$(SBINDIR)/tap-mq-destroy
+	rm $(DESTDIR)$(SBINDIR)/tap-mq-init
+	rm $(DESTDIR)$(BINDIR)/tap-mq-pong
+	rm $(DESTDIR)$(UNITDIR)/tap-mq-pong@.service
+	systemctl daemon-reload

--- a/helpers/tap-mq-configure-packet-steering.sh
+++ b/helpers/tap-mq-configure-packet-steering.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+set -e
+
+[[ "$EUID" -ne 0 ]] && {
+  echo >&2 "This script must be run as root."
+  exit 1
+}
+
+[[ "$#" -eq 1 ]] || {
+  echo >&2 "usage: $0 <interface>"
+  exit 1
+}
+
+interface="$1"; shift
+
+[[ -n "$interface" ]] || {
+  echo >&2 "Non-empty interface name required."
+  exit 1
+}
+
+[[ -e /sys/class/net/"$interface" ]] || {
+  echo >&2 "Interface '$interface' not found."
+  exit 1
+}
+
+timeout=5
+time=0
+
+nprocs="$(
+  getconf _NPROCESSORS_ONLN
+)"
+
+final_queue="$((nprocs - 1))"
+final_rps_cpus="/sys/class/net/${interface}/queues/rx-${final_queue}/rps_cpus"
+final_xps_cpus="/sys/class/net/${interface}/queues/tx-${final_queue}/xps_cpus"
+
+while \
+  [[ ! -f "$final_rps_cpus" ]] \
+    && [[ ! -f "$final_xps_cpus" ]]
+do
+  sleep 1
+  ((time++))
+  [[ "$time" -ge "$timeout" ]] && {
+    echo >&2 "Timeout reached before 'rx-$final_queue' and 'tx-$final_queue'" \
+             "for interface '$interface' existed."
+    exit 1
+  }
+done
+
+for i in \
+  /sys/class/net/${interface}/queues/rx-*/rps_cpus \
+  /sys/class/net/${interface}/queues/tx-*/xps_cpus
+do
+  queue="$(
+    echo "$i" \
+      | sed 's%^.*/[rt]x-%%;s%/[rx]ps_cpus$%%'
+  )"
+  cpumask="$((2 ** queue))"
+  echo "$cpumask" > "$i"
+done

--- a/helpers/tap-mq-destroy.sh
+++ b/helpers/tap-mq-destroy.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+[[ "$EUID" -ne 0 ]] && {
+  echo >&2 "This script must be run as root."
+  exit 1
+}
+
+[[ "$#" -eq 1 ]] || {
+  echo >&2 "usage: $0 <interface>"
+  exit 1
+}
+
+interface="$1"; shift
+
+[[ -n "$interface" ]] || {
+  echo >&2 "Non-empty interface name required."
+  exit 1
+}
+
+ip tuntap del "$interface" mode tap multi_queue

--- a/helpers/tap-mq-init.sh
+++ b/helpers/tap-mq-init.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -e
+
+is_valid_hwaddr() {
+  [[ "$1" =~ ^[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}$ ]] \
+    || return 1
+  return 0
+}
+
+is_valid_ipv4() {
+  [[ "$1" =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]] \
+    || return 1
+  for i in `echo "$1" | sed 's/\./ /g'`; do
+    is_valid_ipv4_octet "$i" \
+      || return 1
+  done
+  return 0
+}
+
+is_valid_ipv4_octet() {
+  [[ "$1" =~ ^[0-9]{1,3}$ ]] \
+    && (( "$1" >= 0 )) \
+    && (( "$1" <= 255 )) \
+    && return 0
+  return 1
+}
+
+is_valid_prefix() {
+  [[ "$1" =~ ^[0-9]{1,2}$ ]] \
+    && (( "$1" >= 0 )) \
+    && (( "$1" <= 32 )) \
+    && return 0
+  return 1
+}
+
+[[ "$EUID" -ne 0 ]] && {
+  echo >&2 "This script must be run as root."
+  exit 1
+}
+
+[[ "$#" -eq 5 ]] || {
+  echo >&2 "usage: $0 <interface> <local_hwaddr> <remote_hwaddr> <local_ipaddr/prefix> <remote_ipaddr[/prefix]>"
+  exit 1
+}
+
+interface="$1"; shift
+local_hwaddr="$1"; shift
+remote_hwaddr="$1"; shift
+local_ipaddr="$1"; shift
+remote_ipaddr="$1"; shift
+
+[[ -n "$interface" ]] || {
+  echo >&2 "Non-empty interface name required."
+  exit 1
+}
+
+is_valid_hwaddr "$local_hwaddr" || {
+  echo >&2 "Invalid local hwaddr '$local_hwaddr'."
+  exit 1
+}
+
+is_valid_hwaddr "$remote_hwaddr" || {
+  echo >&2 "Invalid remote hwaddr '$remote_hwaddr'."
+  exit 1
+}
+
+is_valid_ipv4 "${local_ipaddr%%/*}" || {
+  echo >&2 "Invalid ipv4 address '$local_ipaddr'."
+  exit 1
+}
+
+is_valid_prefix "${local_ipaddr##*/}" || {
+  echo >&2 "Invalid ipv4 prefix '$local_ipaddr'."
+  exit 1
+}
+
+remote_ipaddr="${remote_ipaddr%%/*}"
+
+is_valid_ipv4 "$remote_ipaddr" || {
+  echo >&2 "Invalid ipv4 address '$remote_ipaddr'."
+  exit 1
+}
+
+ip tuntap add "$interface" mode tap multi_queue
+
+echo 1 > "/proc/sys/net/ipv6/conf/${interface}/disable_ipv6"
+
+ip link set "$interface" address "$local_hwaddr" up
+
+ip neighbor add "$remote_ipaddr" lladdr "$remote_hwaddr" dev "$interface"
+
+ip address add "$local_ipaddr" dev "$interface"

--- a/helpers/tap-mq-pong@.service
+++ b/helpers/tap-mq-pong@.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=tap multiqueue ping handler on %I
+After=network.target
+
+[Service]
+Type=simple
+
+EnvironmentFile=-/etc/sysconfig/tap-mq-pong/%I
+
+ExecStartPre=-/usr/sbin/tap-mq-destroy %I
+ExecStartPre=/usr/sbin/tap-mq-init %I \
+  $LOCAL_HWADDR \
+  $REMOTE_HWADDR \
+  $LOCAL_IPADDR \
+  $REMOTE_IPADDR
+
+ExecStart=/usr/bin/tap-mq-pong %I
+
+ExecStartPost=/usr/sbin/tap-mq-configure-packet-steering %I
+
+ExecStopPost=-/usr/sbin/tap-mq-destroy %I
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/helpers/tap0.sysconf
+++ b/helpers/tap0.sysconf
@@ -1,0 +1,11 @@
+# The mac addr applied to the local tap device.
+LOCAL_HWADDR=ee:ee:ee:ee:ee:ee
+
+# The ip addr applied to the local tap device.
+LOCAL_IPADDR=169.254.254.2/24
+
+# The mac addr applied "across" the wire.
+REMOTE_HWADDR=ee:ee:ee:c0:ff:ee
+
+# The ip addr applied "across" the wire.
+REMOTE_IPADDR=169.254.254.1/24

--- a/helpers/tap_mq_pong.c
+++ b/helpers/tap_mq_pong.c
@@ -1,0 +1,284 @@
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <linux/if.h>
+#include <linux/if_tun.h>
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define EXIT_OK          0
+#define EXIT_FAIL        1
+#define EXIT_FAIL_OPTION 2
+
+#define PACKET_BUFFER_SIZE 65535
+
+#define ETHERNET_HEADER_LEN 14
+#define IPV4_HEADER_LEN     20
+#define ICMP_HEADER_LEN      8
+
+#define MAC_ADDR_LEN  6
+#define IPV4_ADDR_LEN 4
+
+#define ETHERNET_HEADER_OFFSET 0
+#define IPV4_HEADER_OFFSET     ETHERNET_HEADER_LEN
+#define ICMP_HEADER_OFFSET     ETHERNET_HEADER_LEN + IPV4_HEADER_LEN
+#define PAYLOAD_OFFSET         ETHERNET_HEADER_LEN + IPV4_HEADER_LEN + ICMP_HEADER_LEN
+
+#define MAC_ADDRS_OFFSET ETHERNET_HEADER_OFFSET
+
+#define IP_VERSION_OFFSET IPV4_HEADER_OFFSET
+#define IPV4_IDENT_OFFSET IPV4_HEADER_OFFSET +  4
+#define IPV4_FLAGS_OFFSET IPV4_HEADER_OFFSET +  6
+#define IPV4_PROTO_OFFSET IPV4_HEADER_OFFSET +  9
+#define IPV4_CKSM_OFFSET  IPV4_HEADER_OFFSET + 10
+#define IPV4_ADDRS_OFFSET IPV4_HEADER_OFFSET + IPV4_HEADER_LEN - IPV4_ADDR_LEN * 2
+
+#define ICMP_TYPE_OFFSET ICMP_HEADER_OFFSET
+#define ICMP_CKSM_OFFSET ICMP_HEADER_OFFSET + 2
+
+char *program_basename;
+
+volatile sig_atomic_t keep_running = 1;
+
+static void sigint_handler(int signal) {
+  keep_running = 0;
+  write(STDERR_FILENO, "\n", 1);
+}
+
+static int setup_signals() {
+  struct sigaction sa;
+  sa.sa_handler = &sigint_handler;
+  sa.sa_flags = SA_RESTART;
+  sigfillset(&sa.sa_mask);
+  if (sigaction(SIGINT, &sa, NULL) == -1) {
+    fprintf(
+      stderr,
+      "%s: Failed to setup signal handler for SIGINT.\n",
+      program_basename
+    );
+    return -1;
+  }
+  return 0;
+}
+
+static void checksum_plus(unsigned char *p, unsigned int n) {
+  unsigned int checksum = ntohs(
+    (uint16_t) (p[0] | ((unsigned int) p[1] << 8))
+  );
+  checksum = ((unsigned long) checksum + n) % 65535;
+  p[0] = (unsigned char) (htons(checksum) & 0xff);
+  p[1] = (unsigned char) ((htons(checksum) >> 8) & 0xff);
+}
+
+static void checksum_minus(unsigned char *p, unsigned int n) {
+  checksum_plus(p, ((unsigned long) 65535 - n));
+}
+
+/*
+ * Treat len bytes as a ring and rotate all bytes in the ring counterclockwise
+ * one position (i.e. one index lower).
+ *
+ * For example, when len is 4, the following transformation occurs.
+ *   [0][1][2][3] ->
+ *   [1][2][3][0]
+ */
+static void rotate_bytes(unsigned char *p, unsigned int len) {
+  unsigned int i = 0;
+  unsigned char tmp = p[i];
+  for (++i; i < len; i++) {
+    p[i - 1] = p[i];
+  }
+  p[i - 1] = tmp;
+}
+
+static void zero_bytes(unsigned char *p, unsigned int len) {
+  for (unsigned int i = 0; i < len; i++) {
+    p[i] = '\0';
+  }
+}
+
+/*
+ * This implementation of tun_alloc_mq() is copied nearly verbatim from the
+ * tuntap documentation.
+ *
+ *   https://github.com/torvalds/linux/blob/f422d2a04fe2e661fd439c19197a162cc9a36416/Documentation/networking/tuntap.txt#L124-L158
+ *
+ * Due to the lack of SPDX License Identifiers in this file, I reached out to
+ * the original author of tun_alloc_mq(), Jason Wang <jasowang@redhat.com>, and
+ * obtained his permission to release this function here under the MIT license.
+ */
+static int tun_alloc_mq(char *dev, int queues, int *fds) {
+  struct ifreq ifr;
+  int fd, err, i;
+
+  if (!dev) {
+    return -1;
+  }
+
+  memset(&ifr, 0, sizeof(ifr));
+  /* Flags: IFF_TUN   - TUN device (no Ethernet headers)
+   *        IFF_TAP   - TAP device
+   *
+   *        IFF_NO_PI - Do not provide packet information
+   *        IFF_MULTI_QUEUE - Create a queue of multiqueue device
+   */
+  ifr.ifr_flags = IFF_TAP | IFF_NO_PI | IFF_MULTI_QUEUE;
+  strcpy(ifr.ifr_name, dev);
+
+  for (i = 0; i < queues; i++) {
+    if ((fd = open("/dev/net/tun", O_RDWR)) < 0) {
+      goto err;
+    }
+    err = ioctl(fd, TUNSETIFF, (void *)&ifr);
+    if (err) {
+      close(fd);
+      goto err;
+    }
+    fds[i] = fd;
+  }
+
+  return 0;
+err:
+  for (--i; i >= 0; i--) {
+    close(fds[i]);
+  }
+  return err;
+}
+
+struct queue_ping_handler_arguments {
+  int fd;
+};
+
+static void *queue_ping_handler(void *args) {
+  struct queue_ping_handler_arguments *qargs = args;
+  int fd = qargs->fd;
+
+  while(keep_running) {
+    unsigned char packet_buffer[PACKET_BUFFER_SIZE];
+    int packet_length = read(fd, packet_buffer, sizeof(packet_buffer));
+
+    if (
+      packet_length < 0
+        || (packet_buffer[IP_VERSION_OFFSET] & 0xf0) != 0x40 // Must be IPv4.
+        || packet_buffer[IPV4_PROTO_OFFSET] != 1             // Must be ICMP.
+        || packet_buffer[ICMP_TYPE_OFFSET] != 8      // Must be echo request.
+    ) {
+      continue;
+    }
+
+    /*
+     * Swap our src and dst mac addrs; to do this our bytes are treated as being
+     * in a ring and rotated halfway around the ring.
+     */
+    for (int i = 0; i < MAC_ADDR_LEN; i++) {
+      rotate_bytes(&packet_buffer[MAC_ADDRS_OFFSET], MAC_ADDR_LEN * 2);
+    }
+
+    checksum_minus(&packet_buffer[IPV4_CKSM_OFFSET], (unsigned int) 1);
+    checksum_plus(&packet_buffer[IPV4_IDENT_OFFSET], (unsigned int) 1);
+
+    checksum_plus(
+      &packet_buffer[IPV4_CKSM_OFFSET],
+      (unsigned int) ntohs(
+        (uint16_t) (
+          packet_buffer[IPV4_FLAGS_OFFSET]
+            | ((unsigned int) packet_buffer[IPV4_FLAGS_OFFSET + 1] << 8)
+        )
+      )
+    );
+    zero_bytes(&packet_buffer[IPV4_FLAGS_OFFSET], 1);
+
+    /*
+     * Swap our src and dst ip addrs; to do this our bytes are treated as being
+     * in a ring and rotated halfway around the ring.
+     */
+    for (int i = 0; i < IPV4_ADDR_LEN; i++) {
+      rotate_bytes(&packet_buffer[IPV4_ADDRS_OFFSET], IPV4_ADDR_LEN * 2);
+    }
+
+    checksum_plus(
+      &packet_buffer[ICMP_CKSM_OFFSET],
+      ((unsigned int) packet_buffer[ICMP_TYPE_OFFSET] << 8)
+    );
+    zero_bytes(&packet_buffer[ICMP_TYPE_OFFSET], 1);
+
+    write(fd, packet_buffer, packet_length);
+  }
+
+  return 0;
+}
+
+static void usage_short(void) {
+  fprintf(
+    stderr,
+    "Usage: %s <interface>\n",
+    program_basename
+  );
+}
+
+int main(int argc, char **argv) {
+  program_basename = basename(argv[0]);
+
+  if (argc < 1) {
+    fprintf(
+      stderr,
+      "%s: Invalid number of arguments supplied.\n",
+      program_basename
+    );
+    usage_short();
+    return EXIT_FAIL_OPTION;
+  }
+
+  char *ifname = argv[1];
+
+  int queue_count = sysconf(_SC_NPROCESSORS_CONF);
+  if (queue_count <= 0) {
+    fprintf(stderr, "%s: Failed to get processor count.\n", program_basename);
+    return EXIT_FAIL;
+  }
+
+  int i;
+  int err;
+  int *fds;
+  fds = (int *)malloc(queue_count * sizeof(int));
+
+  err = tun_alloc_mq(ifname, queue_count, fds);
+  if (err) {
+    fprintf(stderr, "%s: Failed to allocate queues.\n", program_basename);
+    return EXIT_FAIL;
+  }
+
+  struct queue_ping_handler_arguments queue_args[queue_count];
+  pthread_t queue_threads[queue_count];
+  for (i = 0; i < queue_count; i++) {
+    int flags = fcntl(fds[i], F_GETFL, 0);
+    fcntl(fds[i], F_SETFL, flags | O_NONBLOCK);
+
+    queue_args[i].fd = fds[i];
+  }
+
+  setup_signals();
+
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+
+  for (i = 0; i < queue_count; i++) {
+    pthread_create(&queue_threads[i], &attr, queue_ping_handler, (void *)&queue_args[i]);
+  }
+
+  for (i = 0; i < queue_count; i++) {
+    pthread_join(queue_threads[i], NULL);
+  }
+
+  free(fds);
+
+  return 0;
+}

--- a/provisioners/centos/kernel-ml-rebuild-tun.sh
+++ b/provisioners/centos/kernel-ml-rebuild-tun.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -e
+
+uname_r="`uname -r`"
+kver="${uname_r%%-*}"
+kver="${kver%%.0}"
+kmaj="${uname_r%%.*}"
+
+curl -LO https://www.kernel.org/pub/linux/kernel/v"$kmaj".x/linux-"$kver".tar.xz
+tar xf linux-"$kver".tar.xz
+cd linux-"$kver"/
+
+cp /boot/config-"$uname_r" .config
+sed -i '/\.ndo_select_queue.*=/d' drivers/net/tun.c
+
+yum install -y \
+  bc \
+  bison \
+  elfutils-libelf-devel \
+  flex \
+  openssl-devel
+
+make drivers/net/tun.ko
+
+install -m 644 -D drivers/net/tun.ko "/lib/modules/${uname_r}/extra/kmod-rxtx-tun/tun.ko"
+depmod -a
+
+modprobe tun

--- a/provisioners/centos/kernel-ml.sh
+++ b/provisioners/centos/kernel-ml.sh
@@ -9,7 +9,8 @@ rpm --import \
   /etc/pki/rpm-gpg/RPM-GPG-KEY-elrepo.org
 
 yum install -y --enablerepo=elrepo-kernel \
-  kernel-ml
+  kernel-ml \
+  kernel-ml-devel
 
 yum swap -y --enablerepo=elrepo-kernel \
   kernel-headers -- kernel-ml-headers

--- a/provisioners/centos/requires.sh
+++ b/provisioners/centos/requires.sh
@@ -7,6 +7,8 @@ rpm --import \
 
 yum install -y \
   gcc \
+  git \
+  "kernel-devel-uname-r == `uname -r`" \
   libpcap-devel \
   make \
   tcpdump

--- a/provisioners/centos/tap0.sh
+++ b/provisioners/centos/tap0.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+cd /vagrant/helpers
+
+make clean
+make
+
+make install
+
+install -m 644 tap0.sysconf /etc/sysconfig/tap-mq-pong/tap0
+
+systemctl start tap-mq-pong@tap0
+systemctl enable tap-mq-pong@tap0

--- a/provisioners/netmap.sh
+++ b/provisioners/netmap.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+git clone https://github.com/luigirizzo/netmap/
+
+cd netmap
+./configure --no-drivers
+make
+make install
+cd -
+
+depmod -a
+modprobe netmap

--- a/provisioners/ubuntu/requires.sh
+++ b/provisioners/ubuntu/requires.sh
@@ -6,6 +6,12 @@ export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y \
   gcc \
+  git \
+  libelf-dev \
   libpcap-dev \
+  "linux-headers-`uname -r`" \
   make \
   tcpdump
+
+echo 'search extra' > /etc/depmod.d/extra.conf
+depmod -a

--- a/runner.sh
+++ b/runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 [[ -z ${RUNNER_VAGRANT_MACHINE+x} ]] &&
-  RUNNER_VAGRANT_MACHINE="seven"
+  RUNNER_VAGRANT_MACHINE="seven-ml"
 
 do_rsync=0
 vagrant status "$RUNNER_VAGRANT_MACHINE" | grep -q "${RUNNER_VAGRANT_MACHINE} *running" &&

--- a/runner.sh
+++ b/runner.sh
@@ -4,10 +4,8 @@
   RUNNER_VAGRANT_MACHINE="seven"
 
 do_rsync=0
-if echo "$RUNNER_VAGRANT_MACHINE" | grep -q '^trusty$\|^xenial$\|^bionic$'; then
-  vagrant status "$RUNNER_VAGRANT_MACHINE" | grep -q "${RUNNER_VAGRANT_MACHINE}.*running" &&
-    do_rsync=1
-fi
+vagrant status "$RUNNER_VAGRANT_MACHINE" | grep -q "${RUNNER_VAGRANT_MACHINE} *running" &&
+  do_rsync=1
 
 vagrant up "$RUNNER_VAGRANT_MACHINE"
 ((do_rsync)) && vagrant rsync "$RUNNER_VAGRANT_MACHINE"

--- a/test.sh
+++ b/test.sh
@@ -2,8 +2,6 @@
 
 set -e
 
-. <(grep '^ID=' /etc/os-release | sed 's/^/OS_RELEASE_/')
-
 rvm --version 2>/dev/null || {
   gpg --keyserver hkp://keys.gnupg.net \
       --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \
@@ -25,7 +23,9 @@ rvm list strings | grep -q "^ruby-${ruby_version}\$" || {
 gem install --conservative bundler
 
 bundle install
-[[ $OS_RELEASE_ID == "centos" ]] &&
-  bundle exec cucumber --tags 'not @ExcludeFromCentOS'
-[[ $OS_RELEASE_ID == "ubuntu" ]] &&
-  bundle exec cucumber --tags 'not @ExcludeFromUbuntu'
+
+cucumber_tags='not @Null'
+grep -q '^CONFIG_BOOTPARAM_HOTPLUG_CPU0=y$' "/boot/config-`uname -r`" ||
+  cucumber_tags='not @RequireHotplugCpu0'
+
+bundle exec cucumber --tags "$cucumber_tags"


### PR DESCRIPTION
These changes improve our test environments in the following ways (most of which are to make the environments suitable for one or more of the planned rxtxqueue implementations; PACKET_FANOUT_QM and netmap implementations are planned in the near future).
• Add netmap.
• Get rid of virtualbox synced folders; it's a pain to keep guest additions working on kernel-ml, so why bother when rsync does the trick.
• Make seven-ml the default vm (PACKET_FANOUT_QM is too recent for vanilla CentOS-7 kernel; let's use kernel-ml by default since it supports PACKET_FANOUT_{CPU,QM,CBPF,EBPF} and netmap).
• Rebuild tun.ko without ndo_select_queue; this makes it easy to use taskset to steer packets from standard userspace utils to specific queues (by configuring xps to map cpus to queues one-to-one).
• Add tap-mq-pong (a multiqueue tap device ping handler) and provision a tap0 device. This will let us interface with tap0 for rxtxqueue testing in the same way we interface with lo for rxtxcpu testing.
• Rework test exclusion logic for tests requiring hotplug support on cpu0 (this isn't quite a provisioner improvement, but it's needed due to the introduction of kernel-ml, so it is related to the recent provisioner improvements).