### PR TITLE
Fix fanout_group_id.

### DIFF
--- a/features/fanout_group.feature
+++ b/features/fanout_group.feature
@@ -1,0 +1,13 @@
+Feature: fanout_group
+
+  Scenario: fanout_group_id is properly set
+    Given I wait 2 seconds for a command to start up
+    When I run `sudo timeout -s INT 7 hold-fanout-group-id-zero` in background
+    And I run `sudo timeout -s INT 5 ../../rxtxcpu lo` in background
+    And I run `taskset -c 0 ping -c2 localhost`
+    Then the output from "sudo timeout -s INT 5 ../../rxtxcpu lo" should contain exactly:
+    """
+    8 packets captured on cpu0.
+    0 packets captured on cpu1.
+    8 packets captured total.
+    """

--- a/helpers/Makefile
+++ b/helpers/Makefile
@@ -21,7 +21,12 @@ ifndef UNITDIR
 UNITDIR = $(PREFIX)/lib/systemd/system
 endif
 
+all: hold-fanout-group-id-zero tap-mq-pong
+
 tap-mq-pong: tap_mq_pong.c
+	$(CC) $(CFLAGS) -std=c99 -D_POSIX_C_SOURCE=200809L -o $@ $^ -lpthread
+
+hold-fanout-group-id-zero: hold_fanout_group_id_zero.c
 	$(CC) $(CFLAGS) -std=c99 -D_POSIX_C_SOURCE=200809L -o $@ $^ -lpthread
 
 .PHONY: clean
@@ -37,6 +42,7 @@ install: /vagrant/Vagrantfile tap-mq-configure-packet-steering.sh tap-mq-destroy
 	mkdir -p $(DESTDIR)$(SBINDIR)
 	mkdir -p $(DESTDIR)$(UNITDIR)
 	mkdir -p $(DESTDIR)$(SYSCONFDIR)/sysconfig/tap-mq-pong/
+	install -m 755 hold-fanout-group-id-zero           $(DESTDIR)$(SBINDIR)/
 	install -m 755 tap-mq-configure-packet-steering.sh $(DESTDIR)$(SBINDIR)/tap-mq-configure-packet-steering
 	install -m 755 tap-mq-destroy.sh                   $(DESTDIR)$(SBINDIR)/tap-mq-destroy
 	install -m 755 tap-mq-init.sh                      $(DESTDIR)$(SBINDIR)/tap-mq-init
@@ -48,6 +54,7 @@ install: /vagrant/Vagrantfile tap-mq-configure-packet-steering.sh tap-mq-destroy
 # See /vagrant/Vagrantfile comment above install target; the same applies to
 # uninstall.
 uninstall: /vagrant/Vagrantfile
+	rm $(DESTDIR)$(SBINDIR)/hold-fanout-group-id-zero
 	rm $(DESTDIR)$(SBINDIR)/tap-mq-configure-packet-steering
 	rm $(DESTDIR)$(SBINDIR)/tap-mq-destroy
 	rm $(DESTDIR)$(SBINDIR)/tap-mq-init

--- a/helpers/hold_fanout_group_id_zero.c
+++ b/helpers/hold_fanout_group_id_zero.c
@@ -1,0 +1,114 @@
+#define _GNU_SOURCE
+
+#include <arpa/inet.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <linux/if.h>
+#include <linux/if_packet.h>
+#include <linux/if_tun.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#define EXIT_OK          0
+#define EXIT_FAIL        1
+#define EXIT_FAIL_OPTION 2
+
+char *program_basename;
+
+volatile sig_atomic_t keep_running = 1;
+
+static void sigint_handler(int signal) {
+  keep_running = 0;
+  write(STDERR_FILENO, "\n", 1);
+}
+
+static int setup_signals() {
+  struct sigaction sa;
+  sa.sa_handler = &sigint_handler;
+  sa.sa_flags = SA_RESTART;
+  sigfillset(&sa.sa_mask);
+  if (sigaction(SIGINT, &sa, NULL) == -1) {
+    fprintf(
+      stderr,
+      "%s: Failed to setup signal handler for SIGINT.\n",
+      program_basename
+    );
+    return -1;
+  }
+  return 0;
+}
+
+static void usage_short(void) {
+  fprintf(
+    stderr,
+    "Usage: %s\n",
+    program_basename
+  );
+}
+
+int main(int argc, char **argv) {
+  program_basename = basename(argv[0]);
+
+  if (argc > 0) {
+    fprintf(
+      stderr,
+      "%s: Invalid number of arguments supplied.\n",
+      program_basename
+    );
+    usage_short();
+    return EXIT_FAIL_OPTION;
+  }
+
+  int queue_count = sysconf(_SC_NPROCESSORS_CONF);
+  if (queue_count <= 0) {
+    fprintf(stderr, "%s: Failed to get processor count.\n", program_basename);
+    return EXIT_FAIL;
+  }
+
+  int i;
+  int *fds;
+  fds = (int *)malloc(queue_count * sizeof(int));
+
+  for (i = 0; i < queue_count; i++) {
+    fds[i] = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    if (fds[i] == -1) {
+      fprintf(
+        stderr,
+        "%s: Failed to create socket: %s\n",
+        program_basename,
+        strerror(errno)
+      );
+      exit(EXIT_FAIL);
+    }
+
+    int fanout_group_id = 0;
+    int fanout_arg = (fanout_group_id | (PACKET_FANOUT_CPU << 16));
+    if (setsockopt(
+          fds[i],
+          SOL_PACKET,
+          PACKET_FANOUT,
+          &fanout_arg,
+          sizeof(fanout_arg)
+        ) < 0) {
+      fprintf(stderr, "%s: Failed to configure fanout.\n", program_basename);
+      exit(EXIT_FAIL);
+    }
+  }
+
+  setup_signals();
+
+  while(keep_running) {
+    sleep(1);
+  }
+
+  free(fds);
+
+  return 0;
+}

--- a/rxtx.c
+++ b/rxtx.c
@@ -144,6 +144,15 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
   }
 
   /*
+   * We need an id to add socket fds to our fanout group.
+   */
+  p->fanout_group_id = getpid() & 0xffff;
+
+  if (args->verbose) {
+    fprintf(stderr, "Generated fanout group id '%d'.\n", p->fanout_group_id);
+  }
+
+  /*
    * This loop creates our rings, including per-ring socket fds and pcap
    * filenames. We need the instantiation order to follow ring index order.
    *
@@ -152,15 +161,6 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
    */
   for (int i = 0; i < args->ring_count; i++) {
     rxtx_ring_init(&(p->rings[i]), p, i);
-  }
-
-  /*
-   * We need an id to add socket fds to our fanout group.
-   */
-  p->fanout_group_id = getpid() & 0xffff;
-
-  if (args->verbose) {
-    fprintf(stderr, "Generated fanout group id '%d'.\n", p->fanout_group_id);
   }
 }
 


### PR DESCRIPTION
5b2842d introduced an ordering where our fanout_group_id was used after
initialization, but before being properly set to a pseudo-unique value. This
caused fanout_group_id to always be 0.

Fix the ordering issue and add a test case to prevent regression.