### PR TITLE
Skip unreliable packets.

### DIFF
--- a/features/affinity.feature
+++ b/features/affinity.feature
@@ -22,3 +22,10 @@ Feature: affinity
     6 packets captured on cpu1.
     6 packets captured total.
     """
+
+  Scenario: Unreliable packets are skipped
+    Given I wait 0.2 seconds for a command to start up
+    When I run `sudo timeout -s INT 2 taskset -c 1 ping -i0 127.0.0.1` in background
+    And I run `sudo timeout -s INT 2 ../../rxtxcpu lo`
+    Then the stdout from "sudo timeout -s INT 2 ../../rxtxcpu lo" should contain "0 packets captured on cpu0."
+    And the stdout from "sudo timeout -s INT 2 ../../rxtxcpu lo" should not contain "0 packets captured on cpu1."

--- a/rxtx.h
+++ b/rxtx.h
@@ -63,10 +63,12 @@ struct rxtx_ring {
   struct rxtx_stats *stats;
   int               idx;
   int               fd;
+  unsigned int      unreliable_packet_count;
 };
 
 struct rxtx_stats {
   uintmax_t       packets_received;
+  unsigned int    packets_unreliable;
   pthread_mutex_t *mutex;
 };
 


### PR DESCRIPTION
Any packets which were enqueued before all socket(), bind(), and setsockopt() operations were completed for our rings should be considered unreliable. These packets could be from another interface (due to being enqueued before bind() set the ifindex) or these packets could belong to another ring (due to being enqueued before all fds are added to our fanout group).