### PR TITLE
Fix pcap dump on stdout.

### DIFF
--- a/rxtx.c
+++ b/rxtx.c
@@ -61,8 +61,6 @@ static void rxtx_pcap_init(struct rxtx_pcap *p, char *filename, int ring_idx);
 static void rxtx_pcap_destroy(struct rxtx_pcap *p);
 static void
 rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, int ring_idx);
-static void
-rxtx_ring_pcap_init(struct rxtx_ring *p, struct rxtx_desc *rtd, int ring_idx);
 static void rxtx_ring_destroy(struct rxtx_ring *p);
 static void rxtx_stats_init(struct rxtx_stats *p);
 static void rxtx_stats_destroy(struct rxtx_stats *p);
@@ -159,7 +157,8 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
     if (!CPU_ISSET(i, &(args->ring_set))) {
       continue;
     }
-    rxtx_ring_pcap_init(&(p->rings[i]), p, i);
+    p->rings[i].pcap = calloc(1, sizeof(*p->rings[i].pcap));
+    rxtx_pcap_init(p->rings[i].pcap, args->pcap_filename, i);
   }
 
   /*
@@ -379,27 +378,6 @@ rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, int ring_idx) {
      *
      *         int shutdown (int socket, int how)
      */
-  }
-}
-
-static void
-rxtx_ring_pcap_init(struct rxtx_ring *p, struct rxtx_desc *rtd, int ring_idx) {
-  /*
-   * We need to init our pcaps after we've successfully opened sockets.
-   * Otherwise the pcap header gets written to stdout even when socket setup
-   * fails.
-   */
-  if (rtd->args->pcap_filename &&
-      strcmp(rtd->args->pcap_filename, "-") == 0) {
-    if (ring_idx == 0) {
-      p->pcap = calloc(1, sizeof(*p->pcap));
-      rxtx_pcap_init(p->pcap, rtd->args->pcap_filename, ring_idx);
-    } else {
-      p->pcap = rtd->rings[0].pcap;
-    }
-  } else {
-    p->pcap = calloc(1, sizeof(*p->pcap));
-    rxtx_pcap_init(p->pcap, rtd->args->pcap_filename, ring_idx);
   }
 }
 


### PR DESCRIPTION
The savefile info when writing to stdout was stashed in ring 0.
c5ce159 fixed another issue, but made it so that savefile info
wasn't initialized for ring 0 when not capturing for ring 0. This
preserves the c5ce159 fix and corrects the stdout behavior.