### PR TITLE
Rework savefile code.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ txcpu
 # Testing files
 /Gemfile.lock
 /tmp/
+test__*__failure
 
 # Vagrant
 /.vagrant/

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ cpu.o rxtx.o: EXTRA_CFLAGS = \
 %.o: %.c
 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -c -o $@ $<
 
-rxtxcpu rxcpu txcpu: cpu.o ext.o interface.o rxtx.o rxtxcpu.o sig.o
+rxtxcpu rxcpu txcpu: cpu.o ext.o interface.o rxtx.o rxtx_savefile.o rxtxcpu.o sig.o
 	$(CC) $(CFLAGS) -o rxtxcpu $^ -lpcap -lpthread
 	rm -f rxcpu txcpu
 	ln -s rxtxcpu rxcpu
@@ -24,7 +24,7 @@ rxtxcpu rxcpu txcpu: cpu.o ext.o interface.o rxtx.o rxtxcpu.o sig.o
 
 .PHONY: clean
 clean:
-	rm -f cpu.o ext.o interface.o rxtx.o rxtxcpu.o sig.o rxtxcpu rxcpu txcpu
+	rm -f cpu.o ext.o interface.o rxtx.o rxtx_savefile.o rxtxcpu.o sig.o rxtxcpu rxcpu txcpu
 
 .PHONY: install
 install: rxtxcpu rxcpu txcpu

--- a/rxtx.h
+++ b/rxtx.h
@@ -11,7 +11,8 @@
 #ifndef _RXTX_H_
 #define _RXTX_H_
 
-#include <pcap.h>    // for pcap_dumper_t, pcap_t
+#include "rxtx_savefile.h" // for rxtx_savefile
+
 #include <pthread.h> // for pthread_mutex_t
 #include <sched.h>   // for cpu_set_t
 #include <stdbool.h> // for bool
@@ -49,15 +50,9 @@ struct rxtx_desc {
   int               fanout_group_id;
 };
 
-struct rxtx_pcap {
-  pcap_t          *desc;
-  char            *filename;
-  pcap_dumper_t   *fp;
-};
-
 struct rxtx_ring {
-  struct rxtx_pcap  *pcap;
   struct rxtx_desc  *rtd;
+  struct rxtx_savefile *savefile;
   struct rxtx_stats *stats;
   int               idx;
   int               fd;

--- a/rxtx_error.h
+++ b/rxtx_error.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef _RXTX_ERROR_H_
+#define _RXTX_ERROR_H_
+
+#include <stdio.h>  // for snprintf()
+#include <string.h> // for strlen()
+
+#define RXTX_ERRBUF_SIZE 512
+#define RXTX_ERROR -1
+
+#define rxtx_fill_errbuf(buf, ...)                           \
+  do {                                                       \
+    int asklen = 0, gotlen = 0;                              \
+    asklen = snprintf(buf, RXTX_ERRBUF_SIZE, ##__VA_ARGS__); \
+    gotlen = strlen(buf);                                    \
+    if (asklen > gotlen && gotlen > 3) {                     \
+      buf[RXTX_ERRBUF_SIZE - 4] = '.';                       \
+      buf[RXTX_ERRBUF_SIZE - 3] = '.';                       \
+      buf[RXTX_ERRBUF_SIZE - 2] = '.';                       \
+    }                                                        \
+  } while (0)
+
+#endif // _RXTX_ERROR_H_

--- a/rxtx_savefile.c
+++ b/rxtx_savefile.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "rxtx_savefile.h"
+#include "rxtx_error.h" // for RXTX_ERROR, rxtx_fill_errbuf()
+
+#include <pcap.h>   // for DLT_EN10MB, pcap_close(), pcap_dump(),
+                    //     pcap_dump_close(), pcap_dump_flush(),
+                    //     pcap_dump_open(), PCAP_ERROR, pcap_geterr(),
+                    //     pcap_open_dead(), pcap_pkthdr
+#include <stdlib.h> // for free()
+#include <string.h> // for strdup()
+
+#define SNAPLEN 65535
+
+#ifdef TESTING
+  #include "tests/rxtx_savefile/helper.h"
+#endif
+
+int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename, char *errbuf) {
+  p->errbuf = errbuf;
+  p->name = strdup(filename);
+  p->pd = pcap_open_dead(DLT_EN10MB, SNAPLEN);
+
+  if (!p->name || !p->pd) {
+    rxtx_fill_errbuf(p->errbuf, "error opening savefile '%s'", filename);
+    return RXTX_ERROR;
+  }
+
+  p->pdd = pcap_dump_open(p->pd, p->name);
+
+  if (!p->pdd) {
+    rxtx_fill_errbuf(p->errbuf, "error opening savefile '%s': libpcap: %s", p->name, pcap_geterr(p->pd));
+    return RXTX_ERROR;
+  }
+
+  return 0;
+}
+
+int rxtx_savefile_dump(struct rxtx_savefile *p, struct pcap_pkthdr *header, u_char *packet, int flush) {
+  pcap_dump((u_char *)p->pdd, header, packet);
+
+  if (flush) {
+    if (pcap_dump_flush(p->pdd) == PCAP_ERROR) {
+      rxtx_fill_errbuf(p->errbuf, "error writing to savefile '%s'", p->name);
+      return RXTX_ERROR;
+    }
+  }
+
+  return 0;
+}
+
+int rxtx_savefile_close(struct rxtx_savefile *p) {
+  int status = 0;
+
+  /*
+   * protect against silent write failures
+   */
+  if ((pcap_dump_flush(p->pdd)) == PCAP_ERROR) {
+    rxtx_fill_errbuf(p->errbuf, "error writing to savefile '%s'", p->name);
+    status = RXTX_ERROR;
+  }
+
+  pcap_dump_close(p->pdd);
+  p->pdd = NULL;
+  pcap_close(p->pd);
+  p->pd = NULL;
+  free(p->name);
+  p->name = NULL;
+  p->errbuf = NULL;
+
+  return status;
+}

--- a/rxtx_savefile.h
+++ b/rxtx_savefile.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef _RXTX_SAVEFILE_H_
+#define _RXTX_SAVEFILE_H_
+
+#include <pcap.h> // for pcap_dumper_t, pcap_pkthdr, pcap_t
+
+struct rxtx_savefile {
+  char *name;
+  pcap_t *pd;
+  pcap_dumper_t *pdd;
+  char *errbuf;
+};
+
+int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename, char *errbuf);
+int rxtx_savefile_dump(struct rxtx_savefile *p, struct pcap_pkthdr *header, u_char *packet, int flush);
+int rxtx_savefile_close(struct rxtx_savefile *p);
+
+#endif // _RXTX_SAVEFILE_H_

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,12 @@
 
 set -e
 
+for i in tests/*/; do
+  cd "$i"
+  make test
+  cd - >/dev/null
+done
+
 rvm --version 2>/dev/null || {
   gpg --keyserver hkp://keys.gnupg.net \
       --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 \

--- a/tests/rxtx_savefile/Makefile
+++ b/tests/rxtx_savefile/Makefile
@@ -1,0 +1,43 @@
+CC = gcc
+CFLAGS = -Wall -Wcast-align -Wcast-qual -Wimplicit -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow
+
+.PHONY: all
+all: \
+  test__rxtx_savefile_open__strdup__failure \
+  test__rxtx_savefile_open__pcap_open_dead__failure \
+  test__rxtx_savefile_open__pcap_dump_open__failure \
+  test__rxtx_savefile_dump__pcap_dump_flush__failure \
+  test__rxtx_savefile_close__pcap_dump_flush__failure
+
+test__rxtx_savefile_open__strdup__failure: EXTRA_CFLAGS = \
+	-DTEST_STRDUP_FAILURE
+
+test__rxtx_savefile_open__pcap_open_dead__failure: EXTRA_CFLAGS = \
+	-DTEST_PCAP_OPEN_DEAD_FAILURE
+
+test__rxtx_savefile_open__pcap_dump_open__failure: EXTRA_CFLAGS = \
+	-DTEST_PCAP_DUMP_OPEN_FAILURE
+
+test__rxtx_savefile_dump__pcap_dump_flush__failure \
+  test__rxtx_savefile_close__pcap_dump_flush__failure: EXTRA_CFLAGS = \
+	-DTEST_PCAP_DUMP_FLUSH_FAILURE
+
+%: %.c ../../rxtx_savefile.c
+	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -o $@ $^ -lpcap -DTESTING
+
+.PHONY: test
+test: all
+	./test__rxtx_savefile_open__strdup__failure
+	./test__rxtx_savefile_open__pcap_open_dead__failure
+	./test__rxtx_savefile_open__pcap_dump_open__failure
+	./test__rxtx_savefile_dump__pcap_dump_flush__failure
+	./test__rxtx_savefile_close__pcap_dump_flush__failure
+
+.PHONY: clean
+clean:
+	rm -f \
+	  test__rxtx_savefile_open__strdup__failure \
+	  test__rxtx_savefile_open__pcap_open_dead__failure \
+	  test__rxtx_savefile_open__pcap_dump_open__failure \
+	  test__rxtx_savefile_dump__pcap_dump_flush__failure \
+	  test__rxtx_savefile_close__pcap_dump_flush__failure

--- a/tests/rxtx_savefile/helper.h
+++ b/tests/rxtx_savefile/helper.h
@@ -23,7 +23,11 @@
 #endif
 
 #ifdef TEST_PCAP_DUMP_FLUSH_FAILURE
+  #include <errno.h> // for ENOSPC
+
   #define pcap_dump_flush(...) -1
+  #undef errno
+  #define errno ENOSPC
 #endif
 
 #endif // _TEST_RXTX_SAVEFILE_HELPER_H_

--- a/tests/rxtx_savefile/helper.h
+++ b/tests/rxtx_savefile/helper.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef _TEST_RXTX_SAVEFILE_HELPER_H_
+#define _TEST_RXTX_SAVEFILE_HELPER_H_
+
+#ifdef TEST_STRDUP_FAILURE
+  #define strdup(...) NULL
+#endif
+
+#ifdef TEST_PCAP_OPEN_DEAD_FAILURE
+  #define pcap_open_dead(...) NULL
+#endif
+
+#ifdef TEST_PCAP_DUMP_OPEN_FAILURE
+  #define pcap_dump_open(...) NULL
+  #define pcap_geterr(...) "some error from libpcap"
+#endif
+
+#ifdef TEST_PCAP_DUMP_FLUSH_FAILURE
+  #define pcap_dump_flush(...) -1
+#endif
+
+#endif // _TEST_RXTX_SAVEFILE_HELPER_H_

--- a/tests/rxtx_savefile/test__rxtx_savefile_close__pcap_dump_flush__failure.c
+++ b/tests/rxtx_savefile/test__rxtx_savefile_close__pcap_dump_flush__failure.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../../rxtx_error.h"
+#include "../../rxtx_savefile.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+
+  struct rxtx_savefile rtp;
+  char errbuf[RXTX_ERRBUF_SIZE];
+  int status;
+
+  status = rxtx_savefile_open(&rtp, "/dev/null", errbuf);
+  assert(status == 0);
+
+  status = rxtx_savefile_close(&rtp);
+  assert(status == -1);
+
+  status = strcmp(errbuf, "error writing to savefile '/dev/null'");
+  assert(status == 0);
+
+  return 0;
+}

--- a/tests/rxtx_savefile/test__rxtx_savefile_close__pcap_dump_flush__failure.c
+++ b/tests/rxtx_savefile/test__rxtx_savefile_close__pcap_dump_flush__failure.c
@@ -24,7 +24,7 @@ int main(void) {
   status = rxtx_savefile_close(&rtp);
   assert(status == -1);
 
-  status = strcmp(errbuf, "error writing to savefile '/dev/null'");
+  status = strcmp(errbuf, "error writing to savefile '/dev/null': No space left on device");
   assert(status == 0);
 
   return 0;

--- a/tests/rxtx_savefile/test__rxtx_savefile_dump__pcap_dump_flush__failure.c
+++ b/tests/rxtx_savefile/test__rxtx_savefile_dump__pcap_dump_flush__failure.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../../rxtx_error.h"
+#include "../../rxtx_savefile.h"
+
+#include <assert.h>
+#include <pcap.h>
+#include <string.h>
+
+u_char packet[] = {
+  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, /* ethernet destination address */
+  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, /* ethernet source address */
+  0x08, 0x06,                         /* ethertype is arp */
+  0x00, 0x01,                         /* arp hardware type */
+  0x08, 0x00,                         /* arp protocol type */
+  0x06,                               /* arp hardware address length */
+  0x04,                               /* arp protocol address length */
+  0x00, 0x01,                         /* arp operation */
+  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, /* arp sender hardware address */
+  0x7f, 0x00, 0x00, 0x01,             /* arp sender protocol address */
+  0xff, 0xff, 0xff, 0xff, 0xff, 0xff, /* arp target hardware address */
+  0x7f, 0x00, 0x00, 0x01,             /* arp target protocol address */
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* padding */
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, /* padding */
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00  /* padding */
+};
+
+int main(void) {
+
+  struct rxtx_savefile rtp;
+  char errbuf[RXTX_ERRBUF_SIZE];
+  int status;
+
+  status = rxtx_savefile_open(&rtp, "/dev/null", errbuf);
+  assert(status == 0);
+
+  struct pcap_pkthdr header;
+  header.caplen     = (bpf_u_int32) sizeof(packet);
+  header.len        = (bpf_u_int32) sizeof(packet);
+  header.ts.tv_sec  = 0;
+  header.ts.tv_usec = 0;
+
+  status = rxtx_savefile_dump(&rtp, &header, packet, 1);
+  assert(status == -1);
+
+  status = strcmp(errbuf, "error writing to savefile '/dev/null'");
+  assert(status == 0);
+
+  rxtx_savefile_close(&rtp);
+
+  return 0;
+}

--- a/tests/rxtx_savefile/test__rxtx_savefile_dump__pcap_dump_flush__failure.c
+++ b/tests/rxtx_savefile/test__rxtx_savefile_dump__pcap_dump_flush__failure.c
@@ -49,7 +49,7 @@ int main(void) {
   status = rxtx_savefile_dump(&rtp, &header, packet, 1);
   assert(status == -1);
 
-  status = strcmp(errbuf, "error writing to savefile '/dev/null'");
+  status = strcmp(errbuf, "error writing to savefile '/dev/null': No space left on device");
   assert(status == 0);
 
   rxtx_savefile_close(&rtp);

--- a/tests/rxtx_savefile/test__rxtx_savefile_open__pcap_dump_open__failure.c
+++ b/tests/rxtx_savefile/test__rxtx_savefile_open__pcap_dump_open__failure.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../../rxtx_error.h"
+#include "../../rxtx_savefile.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+
+  struct rxtx_savefile rtp;
+  char errbuf[RXTX_ERRBUF_SIZE];
+  int status;
+
+  status = rxtx_savefile_open(&rtp, "/dev/null", errbuf);
+  assert(status == -1);
+
+  status = strcmp(errbuf, "error opening savefile '/dev/null': libpcap: some error from libpcap");
+  assert(status == 0);
+
+  return 0;
+}

--- a/tests/rxtx_savefile/test__rxtx_savefile_open__pcap_open_dead__failure.c
+++ b/tests/rxtx_savefile/test__rxtx_savefile_open__pcap_open_dead__failure.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../../rxtx_error.h"
+#include "../../rxtx_savefile.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+
+  struct rxtx_savefile rtp;
+  char errbuf[RXTX_ERRBUF_SIZE];
+  int status;
+
+  status = rxtx_savefile_open(&rtp, "/dev/null", errbuf);
+  assert(status == -1);
+
+  status = strcmp(errbuf, "error opening savefile '/dev/null'");
+  assert(status == 0);
+
+  return 0;
+}

--- a/tests/rxtx_savefile/test__rxtx_savefile_open__strdup__failure.c
+++ b/tests/rxtx_savefile/test__rxtx_savefile_open__strdup__failure.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../../rxtx_error.h"
+#include "../../rxtx_savefile.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+
+  struct rxtx_savefile rtp;
+  char errbuf[RXTX_ERRBUF_SIZE];
+  int status;
+
+  status = rxtx_savefile_open(&rtp, "/dev/null", errbuf);
+  assert(status == -1);
+
+  status = strcmp(errbuf, "error opening savefile '/dev/null'");
+  assert(status == 0);
+
+  return 0;
+}


### PR DESCRIPTION
This PR separates out the core of the savefile code making it more reusable, easier to understand, and easier to test.

It also introduces a new internal return value and error messaging pattern. I hope to replace many of the existing fprintf() and exit() instances with this pattern as I refactor more portions.

Finally, it introduces the first unit tests to the project. I plan to add more of these to complement the existing cucumber/aruba acceptance tests.