### PR TITLE
Clean up unneeded define.

### DIFF
--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -37,7 +37,6 @@
 #define EXIT_FAIL_OPTION 2
 
 #define OPTION_COUNT_BASE 10
-#define OPTION_CPU_LIST_BASE 10
 
 static const struct option long_options[] = {
   {"count",           required_argument, NULL, 'c'},


### PR DESCRIPTION
Prior to the initial commit, the logic found in parse_cpu_list() lived directly in main(). OPTION_CPU_LIST_BASE in rxtxcpu.c was replaced by CPU_LIST_BASE in cpu.c when the logic was moved, but OPTION_CPU_LIST_BASE was mistakenly left in place. Let's clean it up.