### PR TITLE
Rework ring code.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ cpu.o rxtx.o: EXTRA_CFLAGS = \
 %.o: %.c
 	$(CC) $(CFLAGS) $(EXTRA_CFLAGS) -c -o $@ $<
 
-rxtxcpu rxcpu txcpu: cpu.o ext.o interface.o ring_set.o rxtx.o rxtx_savefile.o rxtx_stats.o rxtxcpu.o sig.o
+rxtxcpu rxcpu txcpu: cpu.o ext.o interface.o ring_set.o rxtx.o rxtx_ring.o rxtx_savefile.o rxtx_stats.o rxtxcpu.o sig.o
 	$(CC) $(CFLAGS) -o rxtxcpu $^ -lpcap -lpthread
 	rm -f rxcpu txcpu
 	ln -s rxtxcpu rxcpu
@@ -24,7 +24,7 @@ rxtxcpu rxcpu txcpu: cpu.o ext.o interface.o ring_set.o rxtx.o rxtx_savefile.o r
 
 .PHONY: clean
 clean:
-	rm -f cpu.o ext.o interface.o ring_set.o rxtx.o rxtx_savefile.o rxtx_stats.o rxtxcpu.o sig.o rxtxcpu rxcpu txcpu
+	rm -f cpu.o ext.o interface.o ring_set.o rxtx.o rxtx_ring.o rxtx_savefile.o rxtx_stats.o rxtxcpu.o sig.o rxtxcpu rxcpu txcpu
 
 .PHONY: install
 install: rxtxcpu rxcpu txcpu

--- a/ext.c
+++ b/ext.c
@@ -21,7 +21,7 @@
  * Do not include libgen.h otherwise you'll get the POSIX version.
  */
 
-char *ext(char *path) {
+char *ext(const char *path) {
   char *filename = basename(path);
   char *p = strrchr(filename, '.');
   /*

--- a/ext.c
+++ b/ext.c
@@ -12,8 +12,8 @@
 
 #include "ext.h"
 
-#include <stdlib.h> // for malloc()
-#include <string.h> // for GNU basename(), strcpy(), strlen(), strrchr()
+#include <stdio.h>  // for NULL
+#include <string.h> // for GNU basename(), strdup(), strlen(), strrchr()
 
 /* These functions are currently incompatible with the POSIX implementation of
  * basename(). We need the GNU implementation instead.
@@ -57,8 +57,10 @@ char *noext(char *path) {
 }
 
 char *noext_copy(const char *path) {
-  char *path_copy;
-  path_copy = malloc(strlen(path) + 1);
-  strcpy(path_copy, path);
-  return noext(path_copy);
+  char *copy;
+  copy = strdup(path);
+  if (!copy) {
+    return NULL;
+  }
+  return noext(copy);
 }

--- a/ext.h
+++ b/ext.h
@@ -11,7 +11,7 @@
 #ifndef _EXT_H_
 #define _EXT_H_
 
-char *ext(char *path);
+char *ext(const char *path);
 char *noext(char *path);
 char *noext_copy(const char *path);
 

--- a/rxtx.c
+++ b/rxtx.c
@@ -244,7 +244,7 @@ rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, int ring_idx, char *_
   rxtx_stats_init(p->stats, errbuf);
   p->idx = ring_idx;
   p->fd = -1;
-  p->unreliable_packet_count = 0;
+  p->unreliable = 0;
 
   if (rtd->args->fanout_mode != NO_PACKET_FANOUT) {
     /*
@@ -426,7 +426,7 @@ void *rxtx_loop(void *r) {
      * Otherwise, this packet should be seen as unreliable.
      */
     if (!seen_empty_ring &&
-        rxtx_stats_get_packets_unreliable(ring->stats) < ring->unreliable_packet_count) {
+        rxtx_stats_get_packets_unreliable(ring->stats) < ring->unreliable) {
       rxtx_stats_increment_packets_unreliable(ring->stats, INCREMENT_STEP);
       continue;
     }

--- a/rxtx.c
+++ b/rxtx.c
@@ -13,9 +13,9 @@
 #include "rxtx.h"
 
 #include "rxtx_error.h"    // for RXTX_ERRBUF_SIZE, RXTX_ERROR
-#include "rxtx_ring.h"     // for rxtx_ring_mark_packets_in_buffer_as_unreliable()
-#include "rxtx_savefile.h" // for rxtx_savefile_close(), rxtx_savefile_dump(),
-                           //     rxtx_savefile_open()
+#include "rxtx_ring.h"     // for rxtx_ring_mark_packets_in_buffer_as_unreliable(),
+                           //     rxtx_ring_savefile_open()
+#include "rxtx_savefile.h" // for rxtx_savefile_close(), rxtx_savefile_dump()
 #include "rxtx_stats.h"    // for rxtx_stats_destroy(),
                            //     rxtx_stats_destroy_with_mutex(),
                            //     rxtx_stats_get_packets_received(),
@@ -25,7 +25,6 @@
                            //     rxtx_stats_init(),
                            //     rxtx_stats_init_with_mutex()
 
-#include "ext.h"       // for ext(), noext_copy()
 #include "interface.h" // for interface_set_promisc_on()
 #include "sig.h"       // for keep_running
 
@@ -47,9 +46,9 @@
 #include <pthread.h>  // for pthread_self()
 #include <sched.h>    // for sched_getcpu()
 #include <stdbool.h>  // for true
-#include <stdio.h>    // for asprintf(), fprintf(), NULL, stderr, stdout
+#include <stdio.h>    // for fprintf(), NULL, stderr, stdout
 #include <stdlib.h>   // for calloc(), exit(), free()
-#include <string.h>   // for memset(), strcmp(), strdup(), strerror(), strlen()
+#include <string.h>   // for memset(), strerror(), strlen()
 #include <time.h>     // for time()
 #include <unistd.h>   // for getpid()
 
@@ -192,26 +191,7 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
    */
   for_each_set_ring(i, p) {
     if (args->pcap_filename) {
-      p->rings[i].savefile = calloc(1, sizeof(*p->rings[i].savefile));
-
-      char *filename;
-
-      if (strcmp(args->pcap_filename, "-") == 0) {
-        filename = strdup(args->pcap_filename);
-      } else {
-        char *copy = noext_copy(args->pcap_filename);
-        asprintf(
-          &filename,
-          "%s-%d.%s",
-          copy,
-          i,
-          ext(args->pcap_filename)
-        );
-        free(copy);
-      }
-
-      status = rxtx_savefile_open(p->rings[i].savefile, filename, errbuf);
-      free(filename);
+      status = rxtx_ring_savefile_open(&(p->rings[i]), args->pcap_filename);
       if (status == RXTX_ERROR) {
         fprintf(stderr, "%s: %s\n", program_basename, errbuf);
         exit(EXIT_FAIL);

--- a/rxtx.h
+++ b/rxtx.h
@@ -11,7 +11,10 @@
 #ifndef _RXTX_H_
 #define _RXTX_H_
 
-#include "rxtx_savefile.h" // for rxtx_savefile
+struct rxtx_desc;
+struct rxtx_ring;
+
+#include "rxtx_ring.h"     // for rxtx_ring
 #include "rxtx_stats.h"    // for rxtx_stats
 
 #include "ring_set.h" // for for_each_ring_in_size(),
@@ -31,10 +34,6 @@
   for_each_set_ring_in_size((ring), &((rtd)->args->ring_set), (rtd)->args->ring_count)
 
 extern char *program_basename;
-
-struct rxtx_args;
-struct rxtx_desc;
-struct rxtx_ring;
 
 struct rxtx_args {
   bool      capture_rx;
@@ -56,16 +55,6 @@ struct rxtx_desc {
   struct rxtx_stats *stats;
   unsigned int      ifindex;
   int               fanout_group_id;
-};
-
-struct rxtx_ring {
-  struct rxtx_desc  *rtd;
-  struct rxtx_savefile *savefile;
-  struct rxtx_stats *stats;
-  int               idx;
-  int               fd;
-  unsigned int      unreliable;
-  char              *errbuf;
 };
 
 int rxtx_close(struct rxtx_desc *rtd);

--- a/rxtx.h
+++ b/rxtx.h
@@ -64,7 +64,7 @@ struct rxtx_ring {
   struct rxtx_stats *stats;
   int               idx;
   int               fd;
-  unsigned int      unreliable_packet_count;
+  unsigned int      unreliable;
   char              *errbuf;
 };
 

--- a/rxtx.h
+++ b/rxtx.h
@@ -65,6 +65,7 @@ struct rxtx_ring {
   int               idx;
   int               fd;
   unsigned int      unreliable_packet_count;
+  char              *errbuf;
 };
 
 int rxtx_close(struct rxtx_desc *rtd);

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -6,15 +6,22 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#define _GNU_SOURCE
+
 #include "rxtx_ring.h"
-#include "rxtx_error.h" // for RXTX_ERROR, rxtx_fill_errbuf()
-#include "rxtx_stats.h" // for rxtx_stats_increment_tp_packets(),
-                        //     rxtx_stats_increment_tp_drops()
+#include "rxtx_error.h"    // for RXTX_ERROR, rxtx_fill_errbuf()
+#include "rxtx_savefile.h" // for rxtx_savefile_open()
+#include "rxtx_stats.h"    // for rxtx_stats_increment_tp_packets(),
+                           //     rxtx_stats_increment_tp_drops()
+
+#include "ext.h" // for ext(), noext_copy()
 
 #include <linux/if_packet.h> // for PACKET_STATISTICS, tpacket_stats
 #include <sys/socket.h>      // for getsockopt(), socklen_t, SOL_PACKET
 
-#include <string.h> // for strerror()
+#include <stdio.h>  // for asprintf()
+#include <stdlib.h> // for calloc(), free()
+#include <string.h> // for strcmp(), strdup(), strerror()
 #include <errno.h>  // for errno
 
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p) {
@@ -25,6 +32,54 @@ int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p) {
 
   p->unreliable = rxtx_stats_get_tp_packets(p->stats)
                     - rxtx_stats_get_tp_drops(p->stats);
+
+  return 0;
+}
+
+int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template) {
+  int status = 0;
+  char *filename = NULL;
+  char *noext = NULL;
+
+  if (!template) {
+    rxtx_fill_errbuf(p->errbuf, "error opening savefile: invalid template");
+    return RXTX_ERROR;
+  }
+
+  p->savefile = calloc(1, sizeof(*p->savefile));
+  if (!p->savefile) {
+    rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s", strerror(errno));
+    return RXTX_ERROR;
+  }
+
+  if (strcmp(template, "-") == 0) {
+    filename = strdup(template);
+    if (!filename) {
+      rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s", strerror(errno));
+      return RXTX_ERROR;
+    }
+  } else {
+    noext = noext_copy(template);
+    if (!noext) {
+      rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s", strerror(errno));
+      return RXTX_ERROR;
+    }
+
+    status = asprintf(&filename, "%s-%d.%s", noext, p->idx, ext(template));
+    if (status == -1) {
+      rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s", strerror(errno));
+      return RXTX_ERROR;
+    }
+
+    free(noext);
+  }
+
+  status = rxtx_savefile_open(p->savefile, filename, p->errbuf);
+  if (status == RXTX_ERROR) {
+    return RXTX_ERROR;
+  }
+
+  free(filename);
 
   return 0;
 }

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -23,8 +23,8 @@ int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p) {
     return RXTX_ERROR;
   }
 
-  p->unreliable_packet_count = rxtx_stats_get_tp_packets(p->stats)
-                                 - rxtx_stats_get_tp_drops(p->stats);
+  p->unreliable = rxtx_stats_get_tp_packets(p->stats)
+                    - rxtx_stats_get_tp_drops(p->stats);
 
   return 0;
 }

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -17,6 +17,18 @@
 #include <string.h> // for strerror()
 #include <errno.h>  // for errno
 
+int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p) {
+  int status = rxtx_ring_update_tpacket_stats(p);
+  if (status == RXTX_ERROR) {
+    return RXTX_ERROR;
+  }
+
+  p->unreliable_packet_count = rxtx_stats_get_tp_packets(p->stats)
+                                 - rxtx_stats_get_tp_drops(p->stats);
+
+  return 0;
+}
+
 int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p) {
   int status = 0;
   struct tpacket_stats tp_stats;

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -9,6 +9,7 @@
 #define _GNU_SOURCE
 
 #include "rxtx_ring.h"
+#include "rxtx.h"          // for NO_PACKET_FANOUT, rxtx_desc
 #include "rxtx_error.h"    // for RXTX_ERROR, rxtx_fill_errbuf()
 #include "rxtx_savefile.h" // for rxtx_savefile_close(), rxtx_savefile_open()
 #include "rxtx_stats.h"    // for rxtx_stats_destroy(),
@@ -17,13 +18,125 @@
 
 #include "ext.h" // for ext(), noext_copy()
 
-#include <linux/if_packet.h> // for PACKET_STATISTICS, tpacket_stats
-#include <sys/socket.h>      // for getsockopt(), socklen_t, SOL_PACKET
+#include <arpa/inet.h>       // for htons()
+#include <linux/if_packet.h> // for PACKET_FANOUT, PACKET_OUTGOING,
+                             //     PACKET_RX_RING, PACKET_STATISTICS,
+                             //     PACKET_TX_RING, sockaddr_ll, tpacket_req,
+                             //     tpacket_stats
+#include <net/ethernet.h>    // for ETH_P_ALL
+#include <sys/socket.h>      // for AF_PACKET, bind(), getsockopt(),
+                             //     recvfrom(), setsockopt(), SO_RCVTIMEO,
+                             //     SOCK_RAW, sockaddr, socket(), socklen_t,
+                             //     SOL_PACKET, SOL_SOCKET
+#include <sys/time.h>        // for timeval
 
 #include <stdio.h>  // for asprintf()
 #include <stdlib.h> // for calloc(), free()
 #include <string.h> // for strcmp(), strdup(), strerror()
 #include <errno.h>  // for errno
+
+int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, int ring_idx, char *errbuf) {
+  int status = 0;
+
+  p->errbuf = errbuf;
+  p->rtd = rtd;
+
+  p->stats = calloc(1, sizeof(*p->stats));
+  if (!p->stats) {
+    rxtx_fill_errbuf(p->errbuf, "error initializing ring: %s", strerror(errno));
+    return RXTX_ERROR;
+  }
+  rxtx_stats_init(p->stats, errbuf);
+
+  p->idx = ring_idx;
+  p->fd = -1;
+  p->unreliable = 0;
+
+  if (rtd->args->fanout_mode != NO_PACKET_FANOUT) {
+    /*
+     * The AF_PACKET address family gives us a packet socket at layer 2. The
+     * SOCK_RAW socket type gives us packets which include the layer 2 header.
+     * The htons(ETH_P_ALL) protocol gives us all packets from any protocol.
+     */
+    p->fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    if (p->fd == -1) {
+      rxtx_fill_errbuf(p->errbuf, "error creating socket: %s", strerror(errno));
+      return RXTX_ERROR;
+    }
+
+    /*
+     * We're using the default, TPACKET_V1, presently. Updating to TPACKET_V3
+     * would be cool.
+     *
+     * PACKET_RX_RING sets up a mmapped ring buffer for async packet reception.
+     * PACKET_TX_RING sets up a mmapped ring buffer for packet transmission.
+     *
+     * I'm not sure if packets marked with PACKET_OUTGOING end up in the rx
+     * ring buffer or the tx ring buffer. PACKET_TX_RING may only be used for
+     * packets sent by this application, but it doesn't seem to cost much to
+     * set it up.
+     */
+    struct tpacket_req req;
+    memset(&req, 0, sizeof(req));
+
+    status = setsockopt(p->fd, SOL_PACKET, PACKET_RX_RING, (void *)&req, sizeof(req));
+    if (status == -1) {
+      rxtx_fill_errbuf(p->errbuf, "error setting socket option: %s", strerror(errno));
+      return RXTX_ERROR;
+    }
+
+    status = setsockopt(p->fd, SOL_PACKET, PACKET_TX_RING, (void *)&req, sizeof(req));
+    if (status == -1) {
+      rxtx_fill_errbuf(p->errbuf, "error setting socket option: %s", strerror(errno));
+      return RXTX_ERROR;
+    }
+
+    /*
+     * SO_RCVTIMEO sets a timeout for socket i/o system calls like recvfrom().
+     * This gives us an easy way to keep our worker loops from getting stuck
+     * waiting on a packet which may never arrive.
+     */
+    struct timeval receive_timeout;
+    /* no need for memset(), we're initializing every member */
+    receive_timeout.tv_sec = 0;
+    receive_timeout.tv_usec = 10;
+    status = setsockopt(p->fd, SOL_SOCKET, SO_RCVTIMEO, &receive_timeout, sizeof(receive_timeout));
+    if (status == -1) {
+      rxtx_fill_errbuf(p->errbuf, "error setting socket option: %s", strerror(errno));
+      return RXTX_ERROR;
+    }
+
+    /*
+     * Per packet(7), we need to set sll_family, sll_protocol, and sll_ifindex
+     * in the sockaddr_ll we're passing to bind(). The values for sll_family
+     * and sll_protocol are straight out of our earlier call to socket(). The
+     * value for sll_ifindex is from our lookup.
+     */
+    struct sockaddr_ll sll;
+    memset(&sll, 0, sizeof(sll));
+    sll.sll_family = AF_PACKET;
+    sll.sll_protocol = htons(ETH_P_ALL);
+    sll.sll_ifindex = rtd->ifindex;
+
+    status = bind(p->fd, (struct sockaddr *)&sll, sizeof(sll));
+    if (status == -1) {
+      rxtx_fill_errbuf(p->errbuf, "error binding socket: %s", strerror(errno));
+      return RXTX_ERROR;
+    }
+
+    /*
+     * Add the socket to our fanout group using the fanout mode supplied.
+     */
+    int fanout_arg = (rtd->fanout_group_id | (rtd->args->fanout_mode << 16));
+    status = setsockopt(p->fd, SOL_PACKET, PACKET_FANOUT, &fanout_arg, sizeof(fanout_arg));
+    if (status == -1) {
+      rxtx_fill_errbuf(p->errbuf, "error configuring fanout: %s", strerror(errno));
+      return RXTX_ERROR;
+    }
+  }
+
+  return 0;
+}
 
 int rxtx_ring_destroy(struct rxtx_ring *p) {
   p->fd = 0;

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "rxtx_ring.h"
+#include "rxtx_error.h" // for RXTX_ERROR, rxtx_fill_errbuf()
+#include "rxtx_stats.h" // for rxtx_stats_increment_tp_packets(),
+                        //     rxtx_stats_increment_tp_drops()
+
+#include <linux/if_packet.h> // for PACKET_STATISTICS, tpacket_stats
+#include <sys/socket.h>      // for getsockopt(), socklen_t, SOL_PACKET
+
+#include <string.h> // for strerror()
+#include <errno.h>  // for errno
+
+int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p) {
+  int status = 0;
+  struct tpacket_stats tp_stats;
+  socklen_t len = sizeof(tp_stats);
+
+  status = getsockopt(p->fd, SOL_PACKET, PACKET_STATISTICS, &tp_stats, &len);
+  if (status < 0) {
+    rxtx_fill_errbuf(p->errbuf, "error collecting packet statistics: %s", strerror(errno));
+    return RXTX_ERROR;
+  }
+
+  status = rxtx_stats_increment_tp_packets(p->stats, tp_stats.tp_packets);
+  if (status == RXTX_ERROR) {
+    return RXTX_ERROR;
+  }
+
+  return rxtx_stats_increment_tp_drops(p->stats, tp_stats.tp_drops);
+}

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -9,7 +9,22 @@
 #ifndef _RXTX_RING_H_
 #define _RXTX_RING_H_
 
-#include "rxtx.h" // for rxtx_ring
+struct rxtx_desc;
+struct rxtx_ring;
+
+#include "rxtx.h"          // for rxtx_desc
+#include "rxtx_savefile.h" // for rxtx_savefile
+#include "rxtx_stats.h"    // for rxtx_stats
+
+struct rxtx_ring {
+  struct rxtx_desc  *rtd;
+  struct rxtx_savefile *savefile;
+  struct rxtx_stats *stats;
+  int               idx;
+  int               fd;
+  unsigned int      unreliable;
+  char              *errbuf;
+};
 
 int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, int ring_idx, char *errbuf);
 int rxtx_ring_destroy(struct rxtx_ring *p);

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef _RXTX_RING_H_
+#define _RXTX_RING_H_
+
+#include "rxtx.h" // for rxtx_ring
+
+int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p);
+
+#endif // _RXTX_RING_H_

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -11,6 +11,7 @@
 
 #include "rxtx.h" // for rxtx_ring
 
+int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, int ring_idx, char *errbuf);
 int rxtx_ring_destroy(struct rxtx_ring *p);
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p);
 int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template);

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -11,6 +11,7 @@
 
 #include "rxtx.h" // for rxtx_ring
 
+int rxtx_ring_destroy(struct rxtx_ring *p);
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p);
 int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template);
 int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p);

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -28,6 +28,7 @@ struct rxtx_ring {
 
 int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, int ring_idx, char *errbuf);
 int rxtx_ring_destroy(struct rxtx_ring *p);
+void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p);
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p);
 int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template);
 int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p);

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -12,6 +12,7 @@
 #include "rxtx.h" // for rxtx_ring
 
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p);
+int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template);
 int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p);
 
 #endif // _RXTX_RING_H_

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -11,6 +11,7 @@
 
 #include "rxtx.h" // for rxtx_ring
 
+int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p);
 int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p);
 
 #endif // _RXTX_RING_H_

--- a/rxtx_stats.c
+++ b/rxtx_stats.c
@@ -81,6 +81,14 @@ uintmax_t rxtx_stats_get_packets_unreliable(struct rxtx_stats *p) {
   return p->packets_unreliable;
 }
 
+uintmax_t rxtx_stats_get_tp_packets(struct rxtx_stats *p) {
+  return p->tp_packets;
+}
+
+uintmax_t rxtx_stats_get_tp_drops(struct rxtx_stats *p) {
+  return p->tp_drops;
+}
+
 int rxtx_stats_increment_packets_received(struct rxtx_stats *p, int step) {
   int status;
 
@@ -117,6 +125,54 @@ int rxtx_stats_increment_packets_unreliable(struct rxtx_stats *p, int step) {
   }
 
   p->packets_unreliable += step;
+
+  if (p->mutex) {
+    status = pthread_mutex_unlock(p->mutex);
+    if (status) {
+      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s", strerror(status));
+      return RXTX_ERROR;
+    }
+  }
+
+  return 0;
+}
+
+int rxtx_stats_increment_tp_packets(struct rxtx_stats *p, int step) {
+  int status;
+
+  if (p->mutex) {
+    status = pthread_mutex_lock(p->mutex);
+    if (status) {
+      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s", strerror(status));
+      return RXTX_ERROR;
+    }
+  }
+
+  p->tp_packets += step;
+
+  if (p->mutex) {
+    status = pthread_mutex_unlock(p->mutex);
+    if (status) {
+      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s", strerror(status));
+      return RXTX_ERROR;
+    }
+  }
+
+  return 0;
+}
+
+int rxtx_stats_increment_tp_drops(struct rxtx_stats *p, int step) {
+  int status;
+
+  if (p->mutex) {
+    status = pthread_mutex_lock(p->mutex);
+    if (status) {
+      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s", strerror(status));
+      return RXTX_ERROR;
+    }
+  }
+
+  p->tp_drops += step;
 
   if (p->mutex) {
     status = pthread_mutex_unlock(p->mutex);

--- a/rxtx_stats.h
+++ b/rxtx_stats.h
@@ -15,19 +15,29 @@
 struct rxtx_stats {
   uintmax_t packets_received;
   uintmax_t packets_unreliable;
+  uintmax_t tp_packets;
+  uintmax_t tp_drops;
   pthread_mutex_t *mutex;
   char *errbuf;
 };
 
 int rxtx_stats_init(struct rxtx_stats *p, char *errbuf);
 int rxtx_stats_init_with_mutex(struct rxtx_stats *p, char *errbuf);
+
 int rxtx_stats_destroy(struct rxtx_stats *p);
 int rxtx_stats_destroy_with_mutex(struct rxtx_stats *p);
+
 int rxtx_stats_mutex_init(struct rxtx_stats *p);
 int rxtx_stats_mutex_destroy(struct rxtx_stats *p);
+
 uintmax_t rxtx_stats_get_packets_received(struct rxtx_stats *p);
 uintmax_t rxtx_stats_get_packets_unreliable(struct rxtx_stats *p);
+uintmax_t rxtx_stats_get_tp_packets(struct rxtx_stats *p);
+uintmax_t rxtx_stats_get_tp_drops(struct rxtx_stats *p);
+
 int rxtx_stats_increment_packets_received(struct rxtx_stats *p, int step);
 int rxtx_stats_increment_packets_unreliable(struct rxtx_stats *p, int step);
+int rxtx_stats_increment_tp_packets(struct rxtx_stats *p, int step);
+int rxtx_stats_increment_tp_drops(struct rxtx_stats *p, int step);
 
 #endif // _RXTX_STATS_H_

--- a/tests/rxtx_stats/Makefile
+++ b/tests/rxtx_stats/Makefile
@@ -9,7 +9,11 @@ all: \
   test__rxtx_stats_increment_packets_received__pthread_mutex_lock__failure \
   test__rxtx_stats_increment_packets_received__pthread_mutex_unlock__failure \
   test__rxtx_stats_increment_packets_unreliable__pthread_mutex_lock__failure \
-  test__rxtx_stats_increment_packets_unreliable__pthread_mutex_unlock__failure
+  test__rxtx_stats_increment_packets_unreliable__pthread_mutex_unlock__failure \
+  test__rxtx_stats_increment_tp_packets__pthread_mutex_lock__failure \
+  test__rxtx_stats_increment_tp_packets__pthread_mutex_unlock__failure \
+  test__rxtx_stats_increment_tp_drops__pthread_mutex_lock__failure \
+  test__rxtx_stats_increment_tp_drops__pthread_mutex_unlock__failure
 
 test__rxtx_stats_mutex_init__calloc__failure: EXTRA_CFLAGS = \
 	-DTEST_CALLOC_FAILURE
@@ -21,11 +25,15 @@ test__rxtx_stats_mutex_destroy__pthread_mutex_destroy__failure: EXTRA_CFLAGS = \
 	-DTEST_PTHREAD_MUTEX_DESTROY_FAILURE
 
 test__rxtx_stats_increment_packets_received__pthread_mutex_lock__failure \
-  test__rxtx_stats_increment_packets_unreliable__pthread_mutex_lock__failure: EXTRA_CFLAGS = \
+  test__rxtx_stats_increment_packets_unreliable__pthread_mutex_lock__failure \
+  test__rxtx_stats_increment_tp_packets__pthread_mutex_lock__failure \
+  test__rxtx_stats_increment_tp_drops__pthread_mutex_lock__failure: EXTRA_CFLAGS = \
 	-DTEST_PTHREAD_MUTEX_LOCK_FAILURE
 
 test__rxtx_stats_increment_packets_received__pthread_mutex_unlock__failure \
-  test__rxtx_stats_increment_packets_unreliable__pthread_mutex_unlock__failure: EXTRA_CFLAGS = \
+  test__rxtx_stats_increment_packets_unreliable__pthread_mutex_unlock__failure \
+  test__rxtx_stats_increment_tp_packets__pthread_mutex_unlock__failure \
+  test__rxtx_stats_increment_tp_drops__pthread_mutex_unlock__failure: EXTRA_CFLAGS = \
 	-DTEST_PTHREAD_MUTEX_UNLOCK_FAILURE
 
 %: %.c ../../rxtx_stats.c
@@ -40,6 +48,11 @@ test: all
 	./test__rxtx_stats_increment_packets_received__pthread_mutex_unlock__failure
 	./test__rxtx_stats_increment_packets_unreliable__pthread_mutex_lock__failure
 	./test__rxtx_stats_increment_packets_unreliable__pthread_mutex_unlock__failure
+	./test__rxtx_stats_increment_tp_packets__pthread_mutex_lock__failure
+	./test__rxtx_stats_increment_tp_packets__pthread_mutex_unlock__failure
+	./test__rxtx_stats_increment_tp_drops__pthread_mutex_lock__failure
+	./test__rxtx_stats_increment_tp_drops__pthread_mutex_unlock__failure
+
 
 .PHONY: clean
 clean:
@@ -50,4 +63,8 @@ clean:
 	  test__rxtx_stats_increment_packets_received__pthread_mutex_lock__failure \
 	  test__rxtx_stats_increment_packets_received__pthread_mutex_unlock__failure \
 	  test__rxtx_stats_increment_packets_unreliable__pthread_mutex_lock__failure \
-	  test__rxtx_stats_increment_packets_unreliable__pthread_mutex_unlock__failure
+	  test__rxtx_stats_increment_packets_unreliable__pthread_mutex_unlock__failure \
+	  test__rxtx_stats_increment_tp_packets__pthread_mutex_lock__failure \
+	  test__rxtx_stats_increment_tp_packets__pthread_mutex_unlock__failure \
+	  test__rxtx_stats_increment_tp_drops__pthread_mutex_lock__failure \
+	  test__rxtx_stats_increment_tp_drops__pthread_mutex_unlock__failure

--- a/tests/rxtx_stats/test__rxtx_stats_increment_tp_drops__pthread_mutex_lock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_tp_drops__pthread_mutex_lock__failure.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../../rxtx_error.h"
+#include "../../rxtx_stats.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+
+  struct rxtx_stats rts;
+  char errbuf[RXTX_ERRBUF_SIZE];
+  int status;
+
+  status = rxtx_stats_init(&rts, errbuf);
+  assert(status == 0);
+
+  status = rxtx_stats_mutex_init(&rts);
+  assert(status == 0);
+
+  status = rxtx_stats_increment_tp_drops(&rts, 1);
+  assert(status == -1);
+
+  status = strcmp(errbuf, "error locking stats mutex: Invalid argument");
+  assert(status == 0);
+
+  rxtx_stats_mutex_destroy(&rts);
+
+  rxtx_stats_destroy(&rts);
+
+  return 0;
+}

--- a/tests/rxtx_stats/test__rxtx_stats_increment_tp_drops__pthread_mutex_unlock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_tp_drops__pthread_mutex_unlock__failure.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../../rxtx_error.h"
+#include "../../rxtx_stats.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+
+  struct rxtx_stats rts;
+  char errbuf[RXTX_ERRBUF_SIZE];
+  int status;
+
+  status = rxtx_stats_init(&rts, errbuf);
+  assert(status == 0);
+
+  status = rxtx_stats_mutex_init(&rts);
+  assert(status == 0);
+
+  status = rxtx_stats_increment_tp_drops(&rts, 1);
+  assert(status == -1);
+
+  status = strcmp(errbuf, "error unlocking stats mutex: Invalid argument");
+  assert(status == 0);
+
+  rxtx_stats_mutex_destroy(&rts);
+
+  rxtx_stats_destroy(&rts);
+
+  return 0;
+}

--- a/tests/rxtx_stats/test__rxtx_stats_increment_tp_packets__pthread_mutex_lock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_tp_packets__pthread_mutex_lock__failure.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../../rxtx_error.h"
+#include "../../rxtx_stats.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+
+  struct rxtx_stats rts;
+  char errbuf[RXTX_ERRBUF_SIZE];
+  int status;
+
+  status = rxtx_stats_init(&rts, errbuf);
+  assert(status == 0);
+
+  status = rxtx_stats_mutex_init(&rts);
+  assert(status == 0);
+
+  status = rxtx_stats_increment_tp_packets(&rts, 1);
+  assert(status == -1);
+
+  status = strcmp(errbuf, "error locking stats mutex: Invalid argument");
+  assert(status == 0);
+
+  rxtx_stats_mutex_destroy(&rts);
+
+  rxtx_stats_destroy(&rts);
+
+  return 0;
+}

--- a/tests/rxtx_stats/test__rxtx_stats_increment_tp_packets__pthread_mutex_unlock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_tp_packets__pthread_mutex_unlock__failure.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2019-present StackPath, LLC
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "../../rxtx_error.h"
+#include "../../rxtx_stats.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+
+  struct rxtx_stats rts;
+  char errbuf[RXTX_ERRBUF_SIZE];
+  int status;
+
+  status = rxtx_stats_init(&rts, errbuf);
+  assert(status == 0);
+
+  status = rxtx_stats_mutex_init(&rts);
+  assert(status == 0);
+
+  status = rxtx_stats_increment_tp_packets(&rts, 1);
+  assert(status == -1);
+
+  status = strcmp(errbuf, "error unlocking stats mutex: Invalid argument");
+  assert(status == 0);
+
+  rxtx_stats_mutex_destroy(&rts);
+
+  rxtx_stats_destroy(&rts);
+
+  return 0;
+}


### PR DESCRIPTION
These commits separate out the core of the ring code making it more reusable, easier to understand, and easier to test (tests aren't included yet, unfortunately).

It also converts ring functions to the new return value and error messaging pattern.

Supporting code in ext.c saw some improvements in functions used by the ring code as well.