### PR TITLE
Standardizing and solving (or at least testing for) long lines.

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -59,6 +59,7 @@
  */
 #define MAX_ONLINE_CPU_LIST_LENGTH 12915 // 12914 + '\0'
 
+/* ========================================================================= */
 int get_online_cpu_set(cpu_set_t *cpu_set) {
   CPU_ZERO(cpu_set);
 
@@ -76,6 +77,7 @@ int get_online_cpu_set(cpu_set_t *cpu_set) {
   return RETURN_GOOD;
 }
 
+/* ========================================================================= */
 static int hex2int(char c) {
   if (c >= '0' && c <= '9')
     return c - '0';
@@ -86,6 +88,7 @@ static int hex2int(char c) {
   return -1;
 }
 
+/* ========================================================================= */
 int parse_cpu_list(char *cpu_list, cpu_set_t *cpu_set) {
   CPU_ZERO(cpu_set);
 
@@ -135,6 +138,7 @@ int parse_cpu_list(char *cpu_list, cpu_set_t *cpu_set) {
   return RETURN_GOOD;
 }
 
+/* ========================================================================= */
 int parse_cpu_mask(char *cpu_mask, cpu_set_t *cpu_set) {
   CPU_ZERO(cpu_set);
 

--- a/cpu.c
+++ b/cpu.c
@@ -123,8 +123,8 @@ int parse_cpu_list(char *cpu_list, cpu_set_t *cpu_set) {
      *      contains our range delimiter, '-'.
      *   2. Ensure endptr (endptr from the strtol() operation to find last) is
      *      NULL.
-     *   3. Ensure that last is not less than first (procfs accepts ranges where
-     *      last equals first, so we will too).
+     *   3. Ensure that last is not less than first (procfs accepts ranges
+     *       where last equals first, so we will too).
      */
     if (save[0] != '-' || *endptr || last < first) {
       return RETURN_BAD;

--- a/ext.c
+++ b/ext.c
@@ -21,6 +21,7 @@
  * Do not include libgen.h otherwise you'll get the POSIX version.
  */
 
+/* ========================================================================= */
 char *ext(const char *path) {
   char *filename = basename(path);
   char *p = strrchr(filename, '.');
@@ -38,6 +39,7 @@ char *ext(const char *path) {
   return p + 1;
 }
 
+/* ========================================================================= */
 char *noext(char *path) {
   char *filename = basename(path);
   char *p = strrchr(filename, '.');
@@ -56,6 +58,7 @@ char *noext(char *path) {
   return path;
 }
 
+/* ========================================================================= */
 char *noext_copy(const char *path) {
   char *copy;
   copy = strdup(path);

--- a/interface.c
+++ b/interface.c
@@ -14,6 +14,7 @@
                              //     socket(), SOL_PACKET
 #include <string.h>          // for memset()
 
+/* ========================================================================= */
 int interface_set_promisc_on(const unsigned int ifindex) {
   struct packet_mreq mr;
   memset(&mr, 0, sizeof(mr));

--- a/interface.c
+++ b/interface.c
@@ -27,11 +27,6 @@ int interface_set_promisc_on(const unsigned int ifindex) {
     return -1;
   }
 
-  return setsockopt(
-           fd,
-           SOL_PACKET,
-           PACKET_ADD_MEMBERSHIP,
-           (void *)&mr,
-           sizeof(mr)
-         );
+  return setsockopt(fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, (void *)&mr,
+                                                                   sizeof(mr));
 }

--- a/ring_set.c
+++ b/ring_set.c
@@ -8,6 +8,7 @@
 
 #include "ring_set.h"
 
+/* ========================================================================= */
 int find_next_set_ring(int ring, ring_set_t *ring_set) {
   for (; ring < RING_SETSIZE; ring++) {
     if (RING_ISSET(ring, ring_set)) {

--- a/rxtx.c
+++ b/rxtx.c
@@ -170,7 +170,8 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
    */
   for_each_set_ring(i, p) {
     if (args->savefile_template) {
-      status = rxtx_ring_savefile_open(&(p->rings[i]), args->savefile_template);
+      status = rxtx_ring_savefile_open(&(p->rings[i]),
+                                                      args->savefile_template);
       if (status == RXTX_ERROR) {
         fprintf(stderr, "%s: %s\n", program_basename, errbuf);
         exit(EXIT_FAIL);

--- a/rxtx.h
+++ b/rxtx.h
@@ -31,7 +31,8 @@ struct rxtx_ring;
   for_each_ring_in_size((ring), (rtd)->args->ring_count)
 
 #define for_each_set_ring(ring, rtd) \
-  for_each_set_ring_in_size((ring), &((rtd)->args->ring_set), (rtd)->args->ring_count)
+  for_each_set_ring_in_size((ring), &((rtd)->args->ring_set), \
+                                                       (rtd)->args->ring_count)
 
 extern char *program_basename;
 extern volatile sig_atomic_t rxtx_breakloop;

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -52,7 +52,8 @@ int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf) {
 
   p->stats = calloc(1, sizeof(*p->stats));
   if (!p->stats) {
-    rxtx_fill_errbuf(p->errbuf, "error initializing ring: %s", strerror(errno));
+    rxtx_fill_errbuf(p->errbuf, "error initializing ring: %s",
+                                                              strerror(errno));
     return RXTX_ERROR;
   }
   rxtx_stats_init(p->stats, errbuf);
@@ -87,15 +88,19 @@ int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf) {
   struct tpacket_req req;
   memset(&req, 0, sizeof(req));
 
-  status = setsockopt(p->fd, SOL_PACKET, PACKET_RX_RING, (void *)&req, sizeof(req));
+  status = setsockopt(p->fd, SOL_PACKET, PACKET_RX_RING, (void *)&req,
+                                                                  sizeof(req));
   if (status == -1) {
-    rxtx_fill_errbuf(p->errbuf, "error setting socket option: %s", strerror(errno));
+    rxtx_fill_errbuf(p->errbuf, "error setting socket option: %s",
+                                                              strerror(errno));
     return RXTX_ERROR;
   }
 
-  status = setsockopt(p->fd, SOL_PACKET, PACKET_TX_RING, (void *)&req, sizeof(req));
+  status = setsockopt(p->fd, SOL_PACKET, PACKET_TX_RING, (void *)&req,
+                                                                  sizeof(req));
   if (status == -1) {
-    rxtx_fill_errbuf(p->errbuf, "error setting socket option: %s", strerror(errno));
+    rxtx_fill_errbuf(p->errbuf, "error setting socket option: %s",
+                                                              strerror(errno));
     return RXTX_ERROR;
   }
 
@@ -108,9 +113,11 @@ int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf) {
   /* no need for memset(), we're initializing every member */
   receive_timeout.tv_sec = 0;
   receive_timeout.tv_usec = 10;
-  status = setsockopt(p->fd, SOL_SOCKET, SO_RCVTIMEO, &receive_timeout, sizeof(receive_timeout));
+  status = setsockopt(p->fd, SOL_SOCKET, SO_RCVTIMEO, &receive_timeout,
+                                                      sizeof(receive_timeout));
   if (status == -1) {
-    rxtx_fill_errbuf(p->errbuf, "error setting socket option: %s", strerror(errno));
+    rxtx_fill_errbuf(p->errbuf, "error setting socket option: %s",
+                                                              strerror(errno));
     return RXTX_ERROR;
   }
 
@@ -136,9 +143,11 @@ int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf) {
    * Add the socket to our fanout group using the fanout mode supplied.
    */
   int fanout_arg = (rtd->fanout_group_id | (rtd->args->fanout_mode << 16));
-  status = setsockopt(p->fd, SOL_PACKET, PACKET_FANOUT, &fanout_arg, sizeof(fanout_arg));
+  status = setsockopt(p->fd, SOL_PACKET, PACKET_FANOUT, &fanout_arg,
+                                                           sizeof(fanout_arg));
   if (status == -1) {
-    rxtx_fill_errbuf(p->errbuf, "error configuring fanout: %s", strerror(errno));
+    rxtx_fill_errbuf(p->errbuf, "error configuring fanout: %s",
+                                                              strerror(errno));
     return RXTX_ERROR;
   }
 
@@ -237,19 +246,22 @@ int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template) {
   if (strcmp(template, "-") == 0) {
     filename = strdup(template);
     if (!filename) {
-      rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s", strerror(errno));
+      rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s",
+                                                              strerror(errno));
       return RXTX_ERROR;
     }
   } else {
     noext = noext_copy(template);
     if (!noext) {
-      rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s", strerror(errno));
+      rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s",
+                                                              strerror(errno));
       return RXTX_ERROR;
     }
 
     status = asprintf(&filename, "%s-%d.%s", noext, p->idx, ext(template));
     if (status == -1) {
-      rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s", strerror(errno));
+      rxtx_fill_errbuf(p->errbuf, "error opening savefile: %s",
+                                                              strerror(errno));
       return RXTX_ERROR;
     }
 
@@ -274,7 +286,8 @@ int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p) {
 
   status = getsockopt(p->fd, SOL_PACKET, PACKET_STATISTICS, &tp_stats, &len);
   if (status < 0) {
-    rxtx_fill_errbuf(p->errbuf, "error collecting packet statistics: %s", strerror(errno));
+    rxtx_fill_errbuf(p->errbuf, "error collecting packet statistics: %s",
+                                                              strerror(errno));
     return RXTX_ERROR;
   }
 

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -43,6 +43,7 @@
 
 #define PACKET_BUFFER_SIZE 65535
 
+/* ========================================================================= */
 int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf) {
   int status = 0;
 
@@ -146,6 +147,7 @@ int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_ring_destroy(struct rxtx_ring *p) {
   p->fd = 0;
 
@@ -170,6 +172,7 @@ int rxtx_ring_destroy(struct rxtx_ring *p) {
   return 0;
 }
 
+/* ========================================================================= */
 void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p) {
   unsigned char packet[PACKET_BUFFER_SIZE];
   int length = 0;
@@ -201,6 +204,7 @@ void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p) {
   }
 }
 
+/* ========================================================================= */
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p) {
   int status = rxtx_ring_update_tpacket_stats(p);
   if (status == RXTX_ERROR) {
@@ -213,6 +217,7 @@ int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template) {
   int status = 0;
   char *filename = NULL;
@@ -261,6 +266,7 @@ int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p) {
   int status = 0;
   struct tpacket_stats tp_stats;

--- a/rxtx_savefile.c
+++ b/rxtx_savefile.c
@@ -24,7 +24,8 @@
 #endif
 
 /* ========================================================================= */
-int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename, char *errbuf) {
+int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename,
+                                                                char *errbuf) {
   p->errbuf = errbuf;
   p->name = strdup(filename);
   p->pd = pcap_open_dead(DLT_EN10MB, SNAPLEN);
@@ -37,7 +38,8 @@ int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename, char *errb
   p->pdd = pcap_dump_open(p->pd, p->name);
 
   if (!p->pdd) {
-    rxtx_fill_errbuf(p->errbuf, "error opening savefile '%s': libpcap: %s", p->name, pcap_geterr(p->pd));
+    rxtx_fill_errbuf(p->errbuf, "error opening savefile '%s': libpcap: %s",
+                                                  p->name, pcap_geterr(p->pd));
     return RXTX_ERROR;
   }
 
@@ -45,15 +47,18 @@ int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename, char *errb
 }
 
 /* ========================================================================= */
-int rxtx_savefile_dump(struct rxtx_savefile *p, struct pcap_pkthdr *header, u_char *packet, int flush) {
+int rxtx_savefile_dump(struct rxtx_savefile *p, struct pcap_pkthdr *header,
+                                                   u_char *packet, int flush) {
   pcap_dump((u_char *)p->pdd, header, packet);
 
   if (flush) {
     if (pcap_dump_flush(p->pdd) == PCAP_ERROR) {
       /*
-       * pcap_dump_flush() only returns PCAP_ERROR when fflush() returns EOF; errno should be set.
+       * pcap_dump_flush() only returns PCAP_ERROR when fflush() returns EOF;
+       * errno should be set.
        */
-      rxtx_fill_errbuf(p->errbuf, "error writing to savefile '%s': %s", p->name, strerror(errno));
+      rxtx_fill_errbuf(p->errbuf, "error writing to savefile '%s': %s",
+                                                     p->name, strerror(errno));
       return RXTX_ERROR;
     }
   }
@@ -70,9 +75,11 @@ int rxtx_savefile_close(struct rxtx_savefile *p) {
    */
   if ((pcap_dump_flush(p->pdd)) == PCAP_ERROR) {
     /*
-     * pcap_dump_flush() only returns PCAP_ERROR when fflush() returns EOF; errno should be set.
+     * pcap_dump_flush() only returns PCAP_ERROR when fflush() returns EOF;
+     * errno should be set.
      */
-    rxtx_fill_errbuf(p->errbuf, "error writing to savefile '%s': %s", p->name, strerror(errno));
+    rxtx_fill_errbuf(p->errbuf, "error writing to savefile '%s': %s", p->name,
+                                                              strerror(errno));
     status = RXTX_ERROR;
   }
 

--- a/rxtx_savefile.c
+++ b/rxtx_savefile.c
@@ -23,6 +23,7 @@
   #include "tests/rxtx_savefile/helper.h"
 #endif
 
+/* ========================================================================= */
 int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename, char *errbuf) {
   p->errbuf = errbuf;
   p->name = strdup(filename);
@@ -43,6 +44,7 @@ int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename, char *errb
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_savefile_dump(struct rxtx_savefile *p, struct pcap_pkthdr *header, u_char *packet, int flush) {
   pcap_dump((u_char *)p->pdd, header, packet);
 
@@ -59,6 +61,7 @@ int rxtx_savefile_dump(struct rxtx_savefile *p, struct pcap_pkthdr *header, u_ch
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_savefile_close(struct rxtx_savefile *p) {
   int status = 0;
 

--- a/rxtx_savefile.h
+++ b/rxtx_savefile.h
@@ -18,8 +18,10 @@ struct rxtx_savefile {
   char *errbuf;
 };
 
-int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename, char *errbuf);
-int rxtx_savefile_dump(struct rxtx_savefile *p, struct pcap_pkthdr *header, u_char *packet, int flush);
+int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename,
+                                                                 char *errbuf);
+int rxtx_savefile_dump(struct rxtx_savefile *p, struct pcap_pkthdr *header,
+                                                    u_char *packet, int flush);
 int rxtx_savefile_close(struct rxtx_savefile *p);
 
 #endif // _RXTX_SAVEFILE_H_

--- a/rxtx_stats.c
+++ b/rxtx_stats.c
@@ -39,13 +39,15 @@ int rxtx_stats_destroy(struct rxtx_stats *p) {
 int rxtx_stats_mutex_init(struct rxtx_stats *p) {
   p->mutex = calloc(1, sizeof(*p->mutex));
   if (!p->mutex) {
-    rxtx_fill_errbuf(p->errbuf, "error initializing stats mutex: %s", strerror(errno));
+    rxtx_fill_errbuf(p->errbuf, "error initializing stats mutex: %s",
+                                                              strerror(errno));
     return RXTX_ERROR;
   }
 
   int status = pthread_mutex_init(p->mutex, NULL);
   if (status) {
-    rxtx_fill_errbuf(p->errbuf, "error initializing stats mutex: %s", strerror(status));
+    rxtx_fill_errbuf(p->errbuf, "error initializing stats mutex: %s",
+                                                             strerror(status));
     return RXTX_ERROR;
   }
 
@@ -56,7 +58,8 @@ int rxtx_stats_mutex_init(struct rxtx_stats *p) {
 int rxtx_stats_mutex_destroy(struct rxtx_stats *p) {
   int status = pthread_mutex_destroy(p->mutex);
   if (status) {
-    rxtx_fill_errbuf(p->errbuf, "error destroying stats mutex: %s", strerror(status));
+    rxtx_fill_errbuf(p->errbuf, "error destroying stats mutex: %s",
+                                                             strerror(status));
     return RXTX_ERROR;
   }
 
@@ -106,7 +109,8 @@ int rxtx_stats_increment_packets_received(struct rxtx_stats *p, int step) {
   if (p->mutex) {
     status = pthread_mutex_lock(p->mutex);
     if (status) {
-      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s", strerror(status));
+      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s",
+                                                             strerror(status));
       return RXTX_ERROR;
     }
   }
@@ -116,7 +120,8 @@ int rxtx_stats_increment_packets_received(struct rxtx_stats *p, int step) {
   if (p->mutex) {
     status = pthread_mutex_unlock(p->mutex);
     if (status) {
-      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s", strerror(status));
+      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s",
+                                                             strerror(status));
       return RXTX_ERROR;
     }
   }
@@ -131,7 +136,8 @@ int rxtx_stats_increment_packets_unreliable(struct rxtx_stats *p, int step) {
   if (p->mutex) {
     status = pthread_mutex_lock(p->mutex);
     if (status) {
-      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s", strerror(status));
+      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s",
+                                                             strerror(status));
       return RXTX_ERROR;
     }
   }
@@ -141,7 +147,8 @@ int rxtx_stats_increment_packets_unreliable(struct rxtx_stats *p, int step) {
   if (p->mutex) {
     status = pthread_mutex_unlock(p->mutex);
     if (status) {
-      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s", strerror(status));
+      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s",
+                                                             strerror(status));
       return RXTX_ERROR;
     }
   }
@@ -156,7 +163,8 @@ int rxtx_stats_increment_tp_packets(struct rxtx_stats *p, int step) {
   if (p->mutex) {
     status = pthread_mutex_lock(p->mutex);
     if (status) {
-      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s", strerror(status));
+      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s",
+                                                             strerror(status));
       return RXTX_ERROR;
     }
   }
@@ -166,7 +174,8 @@ int rxtx_stats_increment_tp_packets(struct rxtx_stats *p, int step) {
   if (p->mutex) {
     status = pthread_mutex_unlock(p->mutex);
     if (status) {
-      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s", strerror(status));
+      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s",
+                                                             strerror(status));
       return RXTX_ERROR;
     }
   }
@@ -181,7 +190,8 @@ int rxtx_stats_increment_tp_drops(struct rxtx_stats *p, int step) {
   if (p->mutex) {
     status = pthread_mutex_lock(p->mutex);
     if (status) {
-      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s", strerror(status));
+      rxtx_fill_errbuf(p->errbuf, "error locking stats mutex: %s",
+                                                             strerror(status));
       return RXTX_ERROR;
     }
   }
@@ -191,7 +201,8 @@ int rxtx_stats_increment_tp_drops(struct rxtx_stats *p, int step) {
   if (p->mutex) {
     status = pthread_mutex_unlock(p->mutex);
     if (status) {
-      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s", strerror(status));
+      rxtx_fill_errbuf(p->errbuf, "error unlocking stats mutex: %s",
+                                                             strerror(status));
       return RXTX_ERROR;
     }
   }

--- a/rxtx_stats.c
+++ b/rxtx_stats.c
@@ -17,6 +17,7 @@
   #include "tests/rxtx_stats/helper.h"
 #endif
 
+/* ========================================================================= */
 int rxtx_stats_init(struct rxtx_stats *p, char *errbuf) {
   p->errbuf = errbuf;
   p->packets_received = 0;
@@ -25,6 +26,7 @@ int rxtx_stats_init(struct rxtx_stats *p, char *errbuf) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_stats_destroy(struct rxtx_stats *p) {
   p->packets_unreliable = 0;
   p->packets_received = 0;
@@ -33,6 +35,7 @@ int rxtx_stats_destroy(struct rxtx_stats *p) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_stats_mutex_init(struct rxtx_stats *p) {
   p->mutex = calloc(1, sizeof(*p->mutex));
   if (!p->mutex) {
@@ -49,6 +52,7 @@ int rxtx_stats_mutex_init(struct rxtx_stats *p) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_stats_mutex_destroy(struct rxtx_stats *p) {
   int status = pthread_mutex_destroy(p->mutex);
   if (status) {
@@ -62,33 +66,40 @@ int rxtx_stats_mutex_destroy(struct rxtx_stats *p) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_stats_init_with_mutex(struct rxtx_stats *p, char *errbuf) {
   rxtx_stats_init(p, errbuf);
   return rxtx_stats_mutex_init(p);
 }
 
+/* ========================================================================= */
 int rxtx_stats_destroy_with_mutex(struct rxtx_stats *p) {
   int status = rxtx_stats_mutex_destroy(p);
   rxtx_stats_destroy(p);
   return status;
 }
 
+/* ========================================================================= */
 uintmax_t rxtx_stats_get_packets_received(struct rxtx_stats *p) {
   return p->packets_received;
 }
 
+/* ========================================================================= */
 uintmax_t rxtx_stats_get_packets_unreliable(struct rxtx_stats *p) {
   return p->packets_unreliable;
 }
 
+/* ========================================================================= */
 uintmax_t rxtx_stats_get_tp_packets(struct rxtx_stats *p) {
   return p->tp_packets;
 }
 
+/* ========================================================================= */
 uintmax_t rxtx_stats_get_tp_drops(struct rxtx_stats *p) {
   return p->tp_drops;
 }
 
+/* ========================================================================= */
 int rxtx_stats_increment_packets_received(struct rxtx_stats *p, int step) {
   int status;
 
@@ -113,6 +124,7 @@ int rxtx_stats_increment_packets_received(struct rxtx_stats *p, int step) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_stats_increment_packets_unreliable(struct rxtx_stats *p, int step) {
   int status;
 
@@ -137,6 +149,7 @@ int rxtx_stats_increment_packets_unreliable(struct rxtx_stats *p, int step) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_stats_increment_tp_packets(struct rxtx_stats *p, int step) {
   int status;
 
@@ -161,6 +174,7 @@ int rxtx_stats_increment_tp_packets(struct rxtx_stats *p, int step) {
   return 0;
 }
 
+/* ========================================================================= */
 int rxtx_stats_increment_tp_drops(struct rxtx_stats *p, int step) {
   int status;
 

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -151,12 +151,14 @@ int main(int argc, char **argv) {
    * argument. Otherwise '?' is returned for both invalid option and missing
    * option argument.
    */
-  while ((c = getopt_long(argc, argv, ":c:d:hl:m:pUvVw:", long_options, 0)) != -1) {
+  while ((c = getopt_long(argc, argv, ":c:d:hl:m:pUvVw:", long_options, 0))
+                                                                       != -1) {
     switch (c) {
       case 'c':
         args.packet_count = strtoumax(optarg, &endptr, OPTION_COUNT_BASE);
         if (*endptr) {
-          fprintf(stderr, "%s: Invalid count '%s'.\n", program_basename, optarg);
+          fprintf(stderr, "%s: Invalid count '%s'.\n", program_basename,
+                                                                       optarg);
           usage_short();
           return EXIT_FAIL_OPTION;
         }
@@ -170,7 +172,8 @@ int main(int argc, char **argv) {
         } else if (strcmp(optarg, "rxtx") == 0) {
           args.direction = PCAP_D_INOUT;
         } else {
-          fprintf(stderr, "%s: Invalid direction '%s'.\n", program_basename, optarg);
+          fprintf(stderr, "%s: Invalid direction '%s'.\n", program_basename,
+                                                                       optarg);
           usage_short();
           return EXIT_FAIL_OPTION;
         }
@@ -183,7 +186,8 @@ int main(int argc, char **argv) {
       case 'l':
         cpu_list = optarg;
         if (parse_cpu_list(optarg, &(args.ring_set))) {
-          fprintf(stderr, "%s: Invalid cpu list '%s'.\n", program_basename, optarg);
+          fprintf(stderr, "%s: Invalid cpu list '%s'.\n", program_basename,
+                                                                       optarg);
           usage_short();
           return EXIT_FAIL_OPTION;
         }
@@ -192,7 +196,8 @@ int main(int argc, char **argv) {
       case 'm':
         cpu_mask = optarg;
         if (parse_cpu_mask(optarg, &(args.ring_set))) {
-          fprintf(stderr, "%s: Invalid cpu mask '%s'.\n", program_basename, optarg);
+          fprintf(stderr, "%s: Invalid cpu mask '%s'.\n", program_basename,
+                                                                       optarg);
           usage_short();
           return EXIT_FAIL_OPTION;
         }
@@ -219,7 +224,8 @@ int main(int argc, char **argv) {
         break;
 
       case ':':  /* missing option argument */
-        fprintf(stderr, "%s: Option '%s' requires an argument.\n", program_basename, argv[optind-1]);
+        fprintf(stderr, "%s: Option '%s' requires an argument.\n",
+                                             program_basename, argv[optind-1]);
         usage_short();
         return EXIT_FAIL_OPTION;
 
@@ -262,7 +268,8 @@ int main(int argc, char **argv) {
         } else {
           badopt = argv[optind-1];
         }
-        fprintf(stderr, "%s: Unrecognized option '%s'.\n", program_basename, badopt);
+        fprintf(stderr, "%s: Unrecognized option '%s'.\n", program_basename,
+                                                                       badopt);
         if (optopt) {
           free(badopt);
         }
@@ -277,7 +284,8 @@ int main(int argc, char **argv) {
   }
 
   if (cpu_list && cpu_mask) {
-    fprintf(stderr, "%s: -l [--cpu-list] and -m [--cpu-mask] are mutually exclusive.\n", program_basename);
+    fprintf(stderr, "%s: -l [--cpu-list] and -m [--cpu-mask] are mutually"
+                                            " exclusive.\n", program_basename);
     usage_short();
     return EXIT_FAIL_OPTION;
   }
@@ -308,12 +316,8 @@ int main(int argc, char **argv) {
     }
   }
   if (!worker_count) {
-    fprintf(
-      stderr,
-      "%s: No configured cpus present in cpu %s.\n",
-      program_basename,
-      cpu_list ? "list" : "mask"
-    );
+    fprintf(stderr, "%s: No configured cpus present in cpu %s.\n",
+                                 program_basename, cpu_list ? "list" : "mask");
     usage_short();
     return EXIT_FAIL_OPTION;
   }
@@ -342,30 +346,23 @@ int main(int argc, char **argv) {
     }
   }
   if (!worker_count) {
-    fprintf(
-      stderr,
-      "%s: No online cpus present in cpu %s.\n",
-      program_basename,
-      cpu_list ? "list" : "mask"
-    );
+    fprintf(stderr, "%s: No online cpus present in cpu %s.\n",
+                                 program_basename, cpu_list ? "list" : "mask");
     usage_short();
     return EXIT_FAIL_OPTION;
   }
 
-  if (args.savefile_template &&
-      strcmp(args.savefile_template, "-") == 0 &&
-      RING_COUNT(&(args.ring_set)) != 1) {
-    fprintf(
-      stderr,
-      "%s: Write file '-' (stdout) is only permitted when capturing on a single cpu.\n",
-      program_basename
-    );
+  if (args.savefile_template && strcmp(args.savefile_template, "-") == 0 &&
+                                           RING_COUNT(&(args.ring_set)) != 1) {
+    fprintf(stderr, "%s: Write file '-' (stdout) is only permitted when"
+                            " capturing on a single cpu.\n", program_basename);
     usage_short();
     return EXIT_FAIL_OPTION;
   }
 
   if ((optind + 1) < argc) {
-    fprintf(stderr, "%s: Only one interface argument is allowed (got [ ", program_basename);
+    fprintf(stderr, "%s: Only one interface argument is allowed (got [ ",
+                                                             program_basename);
     for (; optind < argc; optind++) {
       fprintf(stderr, "'%s'", argv[optind]);
       if ((optind + 1) < argc)
@@ -410,18 +407,13 @@ int main(int argc, char **argv) {
    * results.
    */
   FILE *out = stdout;
-  if (args.savefile_template &&
-      strcmp(args.savefile_template, "-") == 0) {
+  if (args.savefile_template && strcmp(args.savefile_template, "-") == 0) {
     out = stderr;
   }
   for_each_set_ring(i, &rtd) {
     pthread_join(threads[i], NULL);
-    fprintf(
-      out,
-      "%ju packets captured on cpu%d.\n",
-      rtd.rings[i].stats->packets_received,
-      i
-    );
+    fprintf(out, "%ju packets captured on cpu%d.\n",
+                                      rtd.rings[i].stats->packets_received, i);
   }
 
   pthread_attr_destroy(&attr);

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -53,6 +53,7 @@ static const struct option long_options[] = {
   {0, 0, NULL, 0}
 };
 
+/* ========================================================================= */
 static void usage(void) {
   puts("Usage:");
   printf("  %s [OPTIONS] [INTERFACE]\n\n", program_basename);
@@ -89,6 +90,7 @@ static void usage(void) {
        "                               #   only when capturing on a single cpu.");
 }
 
+/* ========================================================================= */
 static void usage_short(void) {
   fprintf(stderr,
           "Usage: %s [--help] [--count=N] [--cpu-list=CPULIST|--cpu-mask=CPUMASK]\n"
@@ -99,6 +101,7 @@ static void usage_short(void) {
           (int) strlen(program_basename), "");
 }
 
+/* ========================================================================= */
 int main(int argc, char **argv) {
   program_basename = basename(argv[0]);
   int i;

--- a/sig.c
+++ b/sig.c
@@ -42,11 +42,8 @@ int setup_signals(void) {
   sigfillset(&sa.sa_mask);
 
   if (sigaction(SIGINT, &sa, NULL) == -1) {
-    fprintf(
-      stderr,
-      "%s: Failed to setup signal handler for SIGINT.\n",
-      program_basename
-    );
+    fprintf(stderr, "%s: Failed to setup signal handler for SIGINT.\n",
+                                                             program_basename);
     return -1;
   }
 

--- a/sig.c
+++ b/sig.c
@@ -16,12 +16,13 @@
 #include <stdio.h>  // for fprintf()
 #include <unistd.h> // for STDERR_FILENO, write()
 
-
+/* ========================================================================= */
 void sigint_handler(int signal) {
   rxtx_set_breakloop_global();
   write(STDERR_FILENO, "\n", 1);
 }
 
+/* ========================================================================= */
 int setup_signals(void) {
   struct sigaction sa;
 

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+./test_ll.sh
+
 for i in tests/*/; do
   cd "$i"
   make test

--- a/test_ll.sh
+++ b/test_ll.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+ATTRS_OFF="` tput sgr0    2>/dev/null`"
+BOLD="`      tput bold    2>/dev/null`"
+BLACK="`     tput setaf 0 2>/dev/null`"
+RED="`       tput setaf 1 2>/dev/null`"
+GREEN="`     tput setaf 2 2>/dev/null`"
+YELLOW="`    tput setaf 3 2>/dev/null`"
+BLUE="`      tput setaf 4 2>/dev/null`"
+MAGENTA="`   tput setaf 5 2>/dev/null`"
+CYAN="`      tput setaf 6 2>/dev/null`"
+LIGHT_GRAY="`tput setaf 7 2>/dev/null`"
+
+for i in *.[ch]; do
+  if echo "$i" | grep -q "^rxtx[a-z][a-z]*\.c$"; then
+    # Usage functions are an exception; we want the output for --help and
+    # similar to be up to 79 characters wide. We let these code lines be over
+    # to accommodate leading whitespace, double quotes, and newline
+    # representations.
+    #
+    # TODO: Add checking of usage functions using inverse awk matches, string
+    #       manipulation equivalent to the following statement, and finally
+    #       our length check.
+    #
+    #         sed 's/^[^"]*"//;s/\\n"$//;s/");$//'
+    #
+    ll="$(
+      awk '
+        length > 79 && !/^ *".*#.*"/ && !/^ *".*\[--.*\]\\n"$/ {
+          print "'"${BOLD}"'" FILENAME ":" FNR ":'"${ATTRS_OFF}"'\t" \
+                                                 "'"${RED}"'"$0"'"${ATTRS_OFF}"'"
+        }
+      ' "$i"
+    )"
+  else
+    ll="$(
+      awk '
+        length > 79 {
+          print "'"${BOLD}"'" FILENAME ":" FNR ":'"${ATTRS_OFF}"'\t" \
+                                                 "'"${RED}"'"$0"'"${ATTRS_OFF}"'"
+        }
+      ' "$i"
+    )"
+  fi
+
+  [[ "$ll" != "" ]] && {
+    echo "${BOLD}${MAGENTA}warning:${ATTRS_OFF} long lines found in '$i'"
+    echo "$ll"
+    echo
+  }
+done
+
+exit 0;


### PR DESCRIPTION
Long lines are always a pain. I've used at least the following standards in the past (not always for C code).

1. Let lines be long. The longer the line gets, the higher the potential for decreased readability.
```
  return setsockopt(fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, (void *)&mr, sizeof(mr));
```

2. A line per-parameter. This looks very good in some languages, especially those with key/value style parameters. I don't think it looks as good for C code. Readability is worse than some other options imo.
```
  return setsockopt(
           fd,
           SOL_PACKET,
           PACKET_ADD_MEMBERSHIP,
           (void *)&mr,
           sizeof(mr)
         );
```

3. First parameter aligned subsequent lines. This doesn't map well to other statements (e.g. if statements).
```
  return setsockopt(fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, (void *)&mr,
                    sizeof(mr));
```

4. Indented subsequent lines. When the statement has an attached block, this version makes subsequent parameters and in-block statements harder to distinguish.
```
  return setsockopt(fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, (void *)&mr,
           sizeof(mr));
```

The solution I've implemented in this PR is to make subsequent lines right justified at 79 chars.

All of the following examples are highly readable imo. The right justification also has the happy property of not requiring indentation changes when the line above changes (e.g. additional indentation, changing a `printf()` to `fprintf()`, etc.).

The right justification makes these easy to follow left to right.
```
  return setsockopt(fd, SOL_PACKET, PACKET_ADD_MEMBERSHIP, (void *)&mr,
                                                                   sizeof(mr));
```
```
      status = rxtx_ring_savefile_open(&(p->rings[i]),
                                                      args->savefile_template);
```
The right justification looks good here too.
```
int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename,
                                                                char *errbuf) {
```
```
int rxtx_savefile_open(struct rxtx_savefile *p, const char *filename,
                                                                 char *errbuf);
```
The right justification helps distinguish the additional conditional logic from the `switch` statement.
```
  while ((c = getopt_long(argc, argv, ":c:d:hl:m:pUvVw:", long_options, 0))
                                                                       != -1) {
    switch (c) {
```
The right justification helps distinguish the additional conditional logic from the `fprintf()`.
```
  if (args.savefile_template && strcmp(args.savefile_template, "-") == 0 &&
                                           RING_COUNT(&(args.ring_set)) != 1) {
    fprintf(stderr, "%s: Write file '-' (stdout) is only permitted when"
                            " capturing on a single cpu.\n", program_basename);
```