### PR TITLE
Improvements and reorganization.

### DIFF
--- a/rxtx.c
+++ b/rxtx.c
@@ -301,7 +301,6 @@ void *rxtx_loop(void *r) {
   struct rxtx_ring *ring = r;
   struct rxtx_desc *rtd = ring->rtd;
   struct rxtx_savefile *savefile = ring->savefile;
-  struct rxtx_args *args = rtd->args;
 
   if (rxtx_verbose_isset(rtd)) {
     fprintf(stderr, "Worker '%lu' handling ring '%d' running on cpu '%d'.\n",

--- a/rxtx.c
+++ b/rxtx.c
@@ -272,6 +272,11 @@ int rxtx_packet_count_reached(struct rxtx_desc *p) {
 
   return 1;
 }
+
+/* ========================================================================= */
+int rxtx_verbose_isset(struct rxtx_desc *p) {
+  return p->args->verbose;
+}
 /* ----------------------------- end of getters ---------------------------- */
 
 /* ---------------------------- start of setters --------------------------- */
@@ -298,7 +303,7 @@ void *rxtx_loop(void *r) {
   struct rxtx_savefile *savefile = ring->savefile;
   struct rxtx_args *args = rtd->args;
 
-  if (args->verbose) {
+  if (rxtx_verbose_isset(rtd)) {
     fprintf(stderr, "Worker '%lu' handling ring '%d' running on cpu '%d'.\n",
                                     pthread_self(), ring->idx, sched_getcpu());
   }

--- a/rxtx.c
+++ b/rxtx.c
@@ -256,6 +256,11 @@ uintmax_t rxtx_get_packets_received(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+int rxtx_packet_buffered_isset(struct rxtx_desc *p) {
+  return p->args->packet_buffered;
+}
+
+/* ========================================================================= */
 int rxtx_packet_count_reached(struct rxtx_desc *p) {
   if (!p->args->packet_count) {
     return 0;
@@ -338,7 +343,7 @@ void *rxtx_loop(void *r) {
 
       int status;
       status = rxtx_savefile_dump(savefile, &header, packet,
-                                                        args->packet_buffered);
+                                              rxtx_packet_buffered_isset(rtd));
 
       if (status == RXTX_ERROR) {
         fprintf(stderr, "%s: %s\n", program_basename, errbuf);

--- a/rxtx.c
+++ b/rxtx.c
@@ -12,42 +12,31 @@
 
 #include "rxtx.h"
 
-#include "rxtx_error.h"    // for RXTX_ERRBUF_SIZE, RXTX_ERROR
-#include "rxtx_ring.h" // for rxtx_ring_clear_unreliable_packets_in_buffer(),
-                       //     rxtx_ring_destroy(), rxtx_ring_init(),
+#include "rxtx_error.h" // for RXTX_ERRBUF_SIZE, RXTX_ERROR
+#include "rxtx_ring.h" // for rxtx_ring_destroy(), rxtx_ring_init(),
                        //     rxtx_ring_mark_packets_in_buffer_as_unreliable(),
                        //     rxtx_ring_savefile_open()
-#include "rxtx_savefile.h" // for rxtx_savefile_dump()
-#include "rxtx_stats.h"    // for rxtx_stats_destroy_with_mutex(),
-                           //     rxtx_stats_get_packets_received(),
-                           //     rxtx_stats_get_packets_unreliable(),
-                           //     rxtx_stats_increment_packets_received(),
-                           //     rxtx_stats_increment_packets_unreliable(),
-                           //     rxtx_stats_init_with_mutex()
+#include "rxtx_stats.h" // for rxtx_stats_destroy_with_mutex(),
+                        //     rxtx_stats_get_packets_received(),
+                        //     rxtx_stats_get_packets_unreliable(),
+                        //     rxtx_stats_increment_packets_received(),
+                        //     rxtx_stats_increment_packets_unreliable(),
+                        //     rxtx_stats_init_with_mutex()
 
 #include "interface.h" // for interface_set_promisc_on()
 #include "sig.h"       // for keep_running
 
-#include <linux/if_packet.h> // for PACKET_OUTGOING, sockaddr_ll
-#include <net/if.h>          // for if_nametoindex()
-#include <sys/socket.h>      // for recvfrom(), setsockopt(), sockaddr,
+#include <net/if.h>     // for if_nametoindex()
+#include <sys/socket.h> // for setsockopt()
 
-#include <pcap.h>     // for bpf_u_int32, PCAP_D_IN, PCAP_D_OUT, pcap_pkthdr
-#include <pthread.h>  // for pthread_self()
-#include <sched.h>    // for sched_getcpu()
-#include <stdio.h>    // for fprintf(), NULL, stderr
-#include <stdlib.h>   // for calloc(), exit(), free()
-#include <time.h>     // for time()
-#include <unistd.h>   // for getpid()
+#include <sched.h>  // for sched_getcpu()
+#include <stdio.h>  // for fprintf(), NULL, stderr
+#include <stdlib.h> // for calloc(), exit(), free()
+#include <unistd.h> // for getpid()
 
 #define EXIT_FAIL 1
 
 #define INCREMENT_STEP 1
-
-#define PACKET_BUFFER_SIZE 65535
-
-#define packet_direction_is_rx(sll) (!packet_direction_is_tx(sll))
-#define packet_direction_is_tx(sll) ((sll)->sll_pkttype == PACKET_OUTGOING)
 
 char errbuf[RXTX_ERRBUF_SIZE] = "";
 char *program_basename = NULL;
@@ -299,65 +288,3 @@ void rxtx_set_breakloop_global(void) {
   rxtx_breakloop = 1;
 }
 /* ----------------------------- end of setters ---------------------------- */
-
-/* ========================================================================= */
-void *rxtx_loop(void *ring) {
-  struct rxtx_ring *p = ring;
-
-  if (rxtx_verbose_isset(p->rtd)) {
-    fprintf(stderr, "Worker '%lu' handling ring '%d' running on cpu '%d'.\n",
-                                       pthread_self(), p->idx, sched_getcpu());
-  }
-
-  rxtx_ring_clear_unreliable_packets_in_buffer(p);
-
-  while (!rxtx_breakloop_isset(p->rtd)) {
-
-    if (rxtx_packet_count_reached(p->rtd)) {
-      break;
-    }
-
-    struct sockaddr_ll sll;
-    unsigned char packet[PACKET_BUFFER_SIZE];
-
-    unsigned int sll_length = sizeof(sll);
-    int packet_length = recvfrom(p->fd, packet, sizeof(packet), 0,
-                                         (struct sockaddr *)&sll, &sll_length);
-
-    if (packet_length == -1) {
-      continue;
-    }
-
-    if (rxtx_get_direction(p->rtd) == PCAP_D_OUT &&
-                                                packet_direction_is_rx(&sll)) {
-      continue;
-    }
-
-    if (rxtx_get_direction(p->rtd) == PCAP_D_IN &&
-                                                packet_direction_is_tx(&sll)) {
-      continue;
-    }
-
-    rxtx_increment_packets_received(p->rtd);
-    rxtx_stats_increment_packets_received(p->stats, INCREMENT_STEP);
-
-    if (p->savefile) {
-      /* no need for memset(), we're initializing every member */
-      struct pcap_pkthdr header;
-      header.caplen     = (bpf_u_int32)packet_length;
-      header.len        = (bpf_u_int32)packet_length;
-      header.ts.tv_sec  = time(NULL);
-      header.ts.tv_usec = 0;
-
-      int status;
-      status = rxtx_savefile_dump(p->savefile, &header, packet,
-                                           rxtx_packet_buffered_isset(p->rtd));
-
-      if (status == RXTX_ERROR) {
-        fprintf(stderr, "%s: %s\n", program_basename, p->errbuf);
-        exit(EXIT_FAIL);
-      }
-    }
-  }
-  return NULL;
-}

--- a/rxtx.c
+++ b/rxtx.c
@@ -231,6 +231,11 @@ int rxtx_breakloop_isset(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+int rxtx_get_fanout_arg(struct rxtx_desc *p) {
+  return p->fanout_group_id | (p->args->fanout_mode << 16);
+}
+
+/* ========================================================================= */
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p) {
   return p->ifindex;
 }

--- a/rxtx.c
+++ b/rxtx.c
@@ -203,12 +203,6 @@ static void rxtx_desc_destroy(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
-static void rxtx_increment_counters(struct rxtx_ring *ring) {
-  rxtx_stats_increment_packets_received(ring->rtd->stats, INCREMENT_STEP);
-  rxtx_stats_increment_packets_received(ring->stats, INCREMENT_STEP);
-}
-
-/* ========================================================================= */
 int rxtx_open(struct rxtx_desc *rtd, struct rxtx_args *args) {
   rxtx_desc_init(rtd, args);
   return 0;
@@ -286,6 +280,16 @@ void rxtx_increment_initialized_ring_count(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+int rxtx_increment_packets_received(struct rxtx_desc *p) {
+  int status = rxtx_stats_increment_packets_received(p->stats, INCREMENT_STEP);
+  if (status == RXTX_ERROR) {
+    return RXTX_ERROR;
+  }
+
+  return 0;
+}
+
+/* ========================================================================= */
 void rxtx_set_breakloop(struct rxtx_desc *p) {
   p->breakloop++;
 }
@@ -334,7 +338,8 @@ void *rxtx_loop(void *ring) {
       continue;
     }
 
-    rxtx_increment_counters(p);
+    rxtx_increment_packets_received(p->rtd);
+    rxtx_stats_increment_packets_received(p->stats, INCREMENT_STEP);
 
     if (p->savefile) {
       /* no need for memset(), we're initializing every member */

--- a/rxtx.c
+++ b/rxtx.c
@@ -231,6 +231,11 @@ int rxtx_breakloop_isset(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+unsigned int rxtx_get_ifindex(struct rxtx_desc *p) {
+  return p->ifindex;
+}
+
+/* ========================================================================= */
 int rxtx_get_initialized_ring_count(struct rxtx_desc *p) {
   return p->initialized_ring_count;
 }

--- a/rxtx.c
+++ b/rxtx.c
@@ -239,6 +239,19 @@ int rxtx_get_initialized_ring_count(struct rxtx_desc *p) {
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p) {
   return rxtx_stats_get_packets_received(p->stats);
 }
+
+/* ========================================================================= */
+int rxtx_packet_count_reached(struct rxtx_desc *p) {
+  if (!p->args->packet_count) {
+    return 0;
+  }
+
+  if (rxtx_stats_get_packets_received(p->stats) < p->args->packet_count) {
+    return 0;
+  }
+
+  return 1;
+}
 /* ----------------------------- end of getters ---------------------------- */
 
 /* ---------------------------- start of setters --------------------------- */
@@ -274,8 +287,7 @@ void *rxtx_loop(void *r) {
 
   while (!rxtx_breakloop_isset(rtd)) {
 
-    if (args->packet_count && rxtx_stats_get_packets_received(rtd->stats)
-                                                       >= args->packet_count) {
+    if (rxtx_packet_count_reached(rtd)) {
       break;
     }
 

--- a/rxtx.c
+++ b/rxtx.c
@@ -231,6 +231,11 @@ int rxtx_breakloop_isset(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+pcap_direction_t rxtx_get_direction(struct rxtx_desc *p) {
+  return p->args->direction;
+}
+
+/* ========================================================================= */
 int rxtx_get_fanout_arg(struct rxtx_desc *p) {
   return p->fanout_group_id | (p->args->fanout_mode << 16);
 }
@@ -312,11 +317,12 @@ void *rxtx_loop(void *r) {
       continue;
     }
 
-    if (args->direction == PCAP_D_OUT && packet_direction_is_rx(&sll)) {
+    if (rxtx_get_direction(rtd) == PCAP_D_OUT &&
+                                                packet_direction_is_rx(&sll)) {
       continue;
     }
 
-    if (args->direction == PCAP_D_IN && packet_direction_is_tx(&sll)) {
+    if (rxtx_get_direction(rtd) == PCAP_D_IN && packet_direction_is_tx(&sll)) {
       continue;
     }
 

--- a/rxtx.c
+++ b/rxtx.c
@@ -234,6 +234,11 @@ int rxtx_breakloop_isset(struct rxtx_desc *p) {
 int rxtx_get_initialized_ring_count(struct rxtx_desc *p) {
   return p->initialized_ring_count;
 }
+
+/* ========================================================================= */
+uintmax_t rxtx_get_packets_received(struct rxtx_desc *p) {
+  return rxtx_stats_get_packets_received(p->stats);
+}
 /* ----------------------------- end of getters ---------------------------- */
 
 /* ---------------------------- start of setters --------------------------- */

--- a/rxtx.h
+++ b/rxtx.h
@@ -70,6 +70,7 @@ int rxtx_get_fanout_arg(struct rxtx_desc *p);
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *rtd);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
+int rxtx_packet_buffered_isset(struct rxtx_desc *p);
 int rxtx_packet_count_reached(struct rxtx_desc *p);
 
 void rxtx_increment_initialized_ring_count(struct rxtx_desc *rtd);

--- a/rxtx.h
+++ b/rxtx.h
@@ -62,7 +62,6 @@ struct rxtx_desc {
 
 int rxtx_open(struct rxtx_desc *rtd, struct rxtx_args *args);
 int rxtx_close(struct rxtx_desc *rtd);
-void *rxtx_loop(void *ring);
 
 int rxtx_breakloop_isset(struct rxtx_desc *p);
 pcap_direction_t rxtx_get_direction(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -65,6 +65,7 @@ int rxtx_close(struct rxtx_desc *rtd);
 void *rxtx_loop(void *r);
 
 int rxtx_breakloop_isset(struct rxtx_desc *p);
+int rxtx_get_fanout_arg(struct rxtx_desc *p);
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *rtd);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -65,6 +65,7 @@ int rxtx_close(struct rxtx_desc *rtd);
 void *rxtx_loop(void *r);
 
 int rxtx_breakloop_isset(struct rxtx_desc *p);
+pcap_direction_t rxtx_get_direction(struct rxtx_desc *p);
 int rxtx_get_fanout_arg(struct rxtx_desc *p);
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *rtd);

--- a/rxtx.h
+++ b/rxtx.h
@@ -62,7 +62,7 @@ struct rxtx_desc {
 
 int rxtx_open(struct rxtx_desc *rtd, struct rxtx_args *args);
 int rxtx_close(struct rxtx_desc *rtd);
-void *rxtx_loop(void *r);
+void *rxtx_loop(void *ring);
 
 int rxtx_breakloop_isset(struct rxtx_desc *p);
 pcap_direction_t rxtx_get_direction(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -66,6 +66,7 @@ void *rxtx_loop(void *r);
 
 int rxtx_breakloop_isset(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *rtd);
+uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
 
 void rxtx_increment_initialized_ring_count(struct rxtx_desc *rtd);
 void rxtx_set_breakloop(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -75,6 +75,7 @@ int rxtx_packet_count_reached(struct rxtx_desc *p);
 int rxtx_verbose_isset(struct rxtx_desc *p);
 
 void rxtx_increment_initialized_ring_count(struct rxtx_desc *rtd);
+int rxtx_increment_packets_received(struct rxtx_desc *p);
 void rxtx_set_breakloop(struct rxtx_desc *p);
 void rxtx_set_breakloop_global(void);
 

--- a/rxtx.h
+++ b/rxtx.h
@@ -72,6 +72,7 @@ int rxtx_get_initialized_ring_count(struct rxtx_desc *rtd);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
 int rxtx_packet_buffered_isset(struct rxtx_desc *p);
 int rxtx_packet_count_reached(struct rxtx_desc *p);
+int rxtx_verbose_isset(struct rxtx_desc *p);
 
 void rxtx_increment_initialized_ring_count(struct rxtx_desc *rtd);
 void rxtx_set_breakloop(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -67,6 +67,7 @@ void *rxtx_loop(void *r);
 int rxtx_breakloop_isset(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *rtd);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
+int rxtx_packet_count_reached(struct rxtx_desc *p);
 
 void rxtx_increment_initialized_ring_count(struct rxtx_desc *rtd);
 void rxtx_set_breakloop(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -65,6 +65,7 @@ int rxtx_close(struct rxtx_desc *rtd);
 void *rxtx_loop(void *r);
 
 int rxtx_breakloop_isset(struct rxtx_desc *p);
+unsigned int rxtx_get_ifindex(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *rtd);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
 int rxtx_packet_count_reached(struct rxtx_desc *p);

--- a/rxtx_error.h
+++ b/rxtx_error.h
@@ -13,7 +13,9 @@
 #include <string.h> // for strlen()
 
 #define RXTX_ERRBUF_SIZE 512
-#define RXTX_ERROR -1
+
+#define RXTX_ERROR   -1
+#define RXTX_TIMEOUT -2
 
 #define rxtx_fill_errbuf(buf, ...)                           \
   do {                                                       \

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -9,7 +9,8 @@
 #define _GNU_SOURCE
 
 #include "rxtx_ring.h"
-#include "rxtx.h" // for rxtx_desc, rxtx_breakloop_isset(), rxtx_get_ifindex(),
+#include "rxtx.h" // for rxtx_desc, rxtx_breakloop_isset(),
+                  //     rxtx_get_fanout_arg(), rxtx_get_ifindex(),
                   //     rxtx_get_initialized_ring_count(),
                   //     rxtx_increment_initialized_ring_count()
 #include "rxtx_error.h"    // for RXTX_ERROR, rxtx_fill_errbuf()
@@ -140,9 +141,9 @@ int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf) {
   }
 
   /*
-   * Add the socket to our fanout group using the fanout mode supplied.
+   * Add the socket to our fanout group using the set fanout mode and group id.
    */
-  int fanout_arg = (rtd->fanout_group_id | (rtd->args->fanout_mode << 16));
+  int fanout_arg = rxtx_get_fanout_arg(rtd);
   status = setsockopt(p->fd, SOL_PACKET, PACKET_FANOUT, &fanout_arg,
                                                            sizeof(fanout_arg));
   if (status == -1) {

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -214,6 +214,11 @@ void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p) {
 }
 
 /* ========================================================================= */
+uintmax_t rxtx_ring_get_packets_received(struct rxtx_ring *p) {
+  return rxtx_stats_get_packets_received(p->stats);
+}
+
+/* ========================================================================= */
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p) {
   int status = rxtx_ring_update_tpacket_stats(p);
   if (status == RXTX_ERROR) {

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -10,13 +10,18 @@
 
 #include "rxtx_ring.h"
 #include "rxtx.h" // for rxtx_desc, rxtx_breakloop_isset(),
-                  //     rxtx_get_fanout_arg(), rxtx_get_ifindex(),
-                  //     rxtx_get_initialized_ring_count(),
-                  //     rxtx_increment_initialized_ring_count()
+                  //     rxtx_get_direction(), rxtx_get_fanout_arg(),
+                  //     rxtx_get_ifindex(), rxtx_get_initialized_ring_count(),
+                  //     rxtx_increment_packets_received(),
+                  //     rxtx_increment_initialized_ring_count(),
+                  //     rxtx_packet_buffered_isset(),
+                  //     rxtx_packet_count_reached()
 #include "rxtx_error.h"    // for RXTX_ERROR, rxtx_fill_errbuf()
-#include "rxtx_savefile.h" // for rxtx_savefile_close(), rxtx_savefile_open()
+#include "rxtx_savefile.h" // for rxtx_savefile_close(), rxtx_savefile_dump(),
+                           //     rxtx_savefile_open()
 #include "rxtx_stats.h"    // for rxtx_stats_destroy(),
                            //     rxtx_stats_get_packets_unreliable(),
+                           //     rxtx_stats_increment_packets_received(),
                            //     rxtx_stats_increment_packets_unreliable(),
                            //     rxtx_stats_increment_tp_packets(),
                            //     rxtx_stats_increment_tp_drops()
@@ -30,19 +35,27 @@
                              //     tpacket_stats
 #include <net/ethernet.h>    // for ETH_P_ALL
 #include <sys/socket.h>      // for AF_PACKET, bind(), getsockopt(),
-                             //     recv(), setsockopt(), SO_RCVTIMEO,
-                             //     SOCK_RAW, sockaddr, socket(), socklen_t,
-                             //     SOL_PACKET, SOL_SOCKET
+                             //     recv(), recvfrom(), setsockopt(),
+                             //     SO_RCVTIMEO, SOCK_RAW, sockaddr, socket(),
+                             //     socklen_t, SOL_PACKET, SOL_SOCKET
 #include <sys/time.h>        // for timeval
 
-#include <stdio.h>  // for asprintf()
-#include <stdlib.h> // for calloc(), free()
-#include <string.h> // for strcmp(), strdup(), strerror()
-#include <errno.h>  // for errno
+#include <errno.h>   // for errno
+#include <pcap.h>    // for bpf_u_int32, PCAP_D_IN, PCAP_D_OUT, pcap_pkthdr
+#include <pthread.h> // for pthread_self()
+#include <stdio.h>   // for asprintf(), fprintf(), NULL, stderr
+#include <stdlib.h>  // for calloc(), exit(), free()
+#include <string.h>  // for strcmp(), strdup(), strerror()
+#include <time.h>    // for time()
+
+#define EXIT_FAIL 1
 
 #define INCREMENT_STEP 1
 
 #define PACKET_BUFFER_SIZE 65535
+
+#define packet_direction_is_rx(sll) (!packet_direction_is_tx(sll))
+#define packet_direction_is_tx(sll) ((sll)->sll_pkttype == PACKET_OUTGOING)
 
 /* ========================================================================= */
 int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf) {
@@ -221,6 +234,68 @@ void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p) {
 /* ========================================================================= */
 uintmax_t rxtx_ring_get_packets_received(struct rxtx_ring *p) {
   return rxtx_stats_get_packets_received(p->stats);
+}
+
+/* ========================================================================= */
+void *rxtx_ring_loop(void *ring) {
+  struct rxtx_ring *p = ring;
+
+  if (rxtx_verbose_isset(p->rtd)) {
+    fprintf(stderr, "Worker '%lu' handling ring '%d' running on cpu '%d'.\n",
+                                       pthread_self(), p->idx, sched_getcpu());
+  }
+
+  rxtx_ring_clear_unreliable_packets_in_buffer(p);
+
+  while (!rxtx_breakloop_isset(p->rtd)) {
+
+    if (rxtx_packet_count_reached(p->rtd)) {
+      break;
+    }
+
+    struct sockaddr_ll sll;
+    unsigned char packet[PACKET_BUFFER_SIZE];
+
+    unsigned int sll_length = sizeof(sll);
+    int packet_length = recvfrom(p->fd, packet, sizeof(packet), 0,
+                                         (struct sockaddr *)&sll, &sll_length);
+
+    if (packet_length == -1) {
+      continue;
+    }
+
+    if (rxtx_get_direction(p->rtd) == PCAP_D_OUT &&
+                                                packet_direction_is_rx(&sll)) {
+      continue;
+    }
+
+    if (rxtx_get_direction(p->rtd) == PCAP_D_IN &&
+                                                packet_direction_is_tx(&sll)) {
+      continue;
+    }
+
+    rxtx_increment_packets_received(p->rtd);
+    rxtx_stats_increment_packets_received(p->stats, INCREMENT_STEP);
+
+    if (p->savefile) {
+      /* no need for memset(), we're initializing every member */
+      struct pcap_pkthdr header;
+      header.caplen     = (bpf_u_int32)packet_length;
+      header.len        = (bpf_u_int32)packet_length;
+      header.ts.tv_sec  = time(NULL);
+      header.ts.tv_usec = 0;
+
+      int status;
+      status = rxtx_savefile_dump(p->savefile, &header, packet,
+                                           rxtx_packet_buffered_isset(p->rtd));
+
+      if (status == RXTX_ERROR) {
+        fprintf(stderr, "%s: %s\n", program_basename, p->errbuf);
+        exit(EXIT_FAIL);
+      }
+    }
+  }
+  return NULL;
 }
 
 /* ========================================================================= */

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -9,9 +9,9 @@
 #define _GNU_SOURCE
 
 #include "rxtx_ring.h"
-#include "rxtx.h"          // for rxtx_desc, rxtx_breakloop_isset(),
-                           //     rxtx_get_initialized_ring_count(),
-                           //     rxtx_increment_initialized_ring_count()
+#include "rxtx.h" // for rxtx_desc, rxtx_breakloop_isset(), rxtx_get_ifindex(),
+                  //     rxtx_get_initialized_ring_count(),
+                  //     rxtx_increment_initialized_ring_count()
 #include "rxtx_error.h"    // for RXTX_ERROR, rxtx_fill_errbuf()
 #include "rxtx_savefile.h" // for rxtx_savefile_close(), rxtx_savefile_open()
 #include "rxtx_stats.h"    // for rxtx_stats_destroy(),
@@ -131,7 +131,7 @@ int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf) {
   memset(&sll, 0, sizeof(sll));
   sll.sll_family = AF_PACKET;
   sll.sll_protocol = htons(ETH_P_ALL);
-  sll.sll_ifindex = rtd->ifindex;
+  sll.sll_ifindex = rxtx_get_ifindex(rtd);
 
   status = bind(p->fd, (struct sockaddr *)&sll, sizeof(sll));
   if (status == -1) {

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -232,6 +232,11 @@ void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p) {
 }
 
 /* ========================================================================= */
+int rxtx_ring_get_idx(struct rxtx_ring *p) {
+  return p->idx;
+}
+
+/* ========================================================================= */
 uintmax_t rxtx_ring_get_packets_received(struct rxtx_ring *p) {
   return rxtx_stats_get_packets_received(p->stats);
 }
@@ -250,7 +255,7 @@ void *rxtx_ring_loop(void *ring) {
 
   if (rxtx_verbose_isset(p->rtd)) {
     fprintf(stderr, "Worker '%lu' handling ring '%d' running on cpu '%d'.\n",
-                                       pthread_self(), p->idx, sched_getcpu());
+                         pthread_self(), rxtx_ring_get_idx(p), sched_getcpu());
   }
 
   rxtx_ring_clear_unreliable_packets_in_buffer(p);

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -209,6 +209,10 @@ void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p) {
 
     /*
      * Otherwise, this packet should be treated as unreliable.
+     *
+     * NOTE: We don't check return here because ring stats should never have a
+     *       mutex and should therefore always return 0.
+     *
      */
     rxtx_stats_increment_packets_unreliable(p->stats, INCREMENT_STEP);
   }

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -32,6 +32,8 @@ void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p);
 uintmax_t rxtx_ring_get_packets_received(struct rxtx_ring *p);
 void *rxtx_ring_loop(void *ring);
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p);
+int rxtx_ring_next_packet(struct rxtx_ring *p, struct pcap_pkthdr *header,
+                                                               u_char *packet);
 int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template);
 int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p);
 

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -29,6 +29,7 @@ struct rxtx_ring {
 int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf);
 int rxtx_ring_destroy(struct rxtx_ring *p);
 void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p);
+uintmax_t rxtx_ring_get_packets_received(struct rxtx_ring *p);
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p);
 int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template);
 int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p);

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -29,6 +29,7 @@ struct rxtx_ring {
 int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf);
 int rxtx_ring_destroy(struct rxtx_ring *p);
 void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p);
+int rxtx_ring_get_idx(struct rxtx_ring *p);
 uintmax_t rxtx_ring_get_packets_received(struct rxtx_ring *p);
 void *rxtx_ring_loop(void *ring);
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p);

--- a/rxtx_ring.h
+++ b/rxtx_ring.h
@@ -30,6 +30,7 @@ int rxtx_ring_init(struct rxtx_ring *p, struct rxtx_desc *rtd, char *errbuf);
 int rxtx_ring_destroy(struct rxtx_ring *p);
 void rxtx_ring_clear_unreliable_packets_in_buffer(struct rxtx_ring *p);
 uintmax_t rxtx_ring_get_packets_received(struct rxtx_ring *p);
+void *rxtx_ring_loop(void *ring);
 int rxtx_ring_mark_packets_in_buffer_as_unreliable(struct rxtx_ring *p);
 int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template);
 int rxtx_ring_update_tpacket_stats(struct rxtx_ring *p);

--- a/rxtx_stats.c
+++ b/rxtx_stats.c
@@ -22,12 +22,16 @@ int rxtx_stats_init(struct rxtx_stats *p, char *errbuf) {
   p->errbuf = errbuf;
   p->packets_received = 0;
   p->packets_unreliable = 0;
+  p->tp_packets = 0;
+  p->tp_drops = 0;
 
   return 0;
 }
 
 /* ========================================================================= */
 int rxtx_stats_destroy(struct rxtx_stats *p) {
+  p->tp_drops = 0;
+  p->tp_packets = 0;
   p->packets_unreliable = 0;
   p->packets_received = 0;
   p->errbuf = NULL;

--- a/rxtx_stats.c
+++ b/rxtx_stats.c
@@ -18,25 +18,22 @@
 #endif
 
 /* ========================================================================= */
-int rxtx_stats_init(struct rxtx_stats *p, char *errbuf) {
+void rxtx_stats_init(struct rxtx_stats *p, char *errbuf) {
   p->errbuf = errbuf;
   p->packets_received = 0;
   p->packets_unreliable = 0;
   p->tp_packets = 0;
   p->tp_drops = 0;
 
-  return 0;
 }
 
 /* ========================================================================= */
-int rxtx_stats_destroy(struct rxtx_stats *p) {
+void rxtx_stats_destroy(struct rxtx_stats *p) {
   p->tp_drops = 0;
   p->tp_packets = 0;
   p->packets_unreliable = 0;
   p->packets_received = 0;
   p->errbuf = NULL;
-
-  return 0;
 }
 
 /* ========================================================================= */

--- a/rxtx_stats.h
+++ b/rxtx_stats.h
@@ -21,10 +21,10 @@ struct rxtx_stats {
   char *errbuf;
 };
 
-int rxtx_stats_init(struct rxtx_stats *p, char *errbuf);
+void rxtx_stats_init(struct rxtx_stats *p, char *errbuf);
 int rxtx_stats_init_with_mutex(struct rxtx_stats *p, char *errbuf);
 
-int rxtx_stats_destroy(struct rxtx_stats *p);
+void rxtx_stats_destroy(struct rxtx_stats *p);
 int rxtx_stats_destroy_with_mutex(struct rxtx_stats *p);
 
 int rxtx_stats_mutex_init(struct rxtx_stats *p);

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -14,9 +14,9 @@
                        //     RING_COUNT(), RING_ISSET(), RING_SET()
 #include "rxtx.h"      // for for_each_set_ring(), program_basename, rxtx_args,
                        //     rxtx_desc, rxtx_close(),
-                       //     rxtx_get_packets_received(), rxtx_loop(),
-                       //     rxtx_open()
-#include "rxtx_ring.h" // for rxtx_ring_get_packets_received()
+                       //     rxtx_get_packets_received(), rxtx_open()
+#include "rxtx_ring.h" // for rxtx_ring_get_packets_received(),
+                       //     rxtx_ring_loop()
 #include "sig.h"       // for setup_signals()
 
 #include <linux/if_packet.h> // for PACKET_FANOUT_CPU
@@ -402,7 +402,8 @@ int main(int argc, char **argv) {
     CPU_ZERO(&cpu_set);
     CPU_SET(i, &cpu_set);
     pthread_attr_setaffinity_np(&attr, sizeof(cpu_set), &cpu_set);
-    pthread_create(&threads[i], &attr, rxtx_loop, (void *)&(rtd.rings[i]));
+    pthread_create(&threads[i], &attr, rxtx_ring_loop,
+                                                      (void *)&(rtd.rings[i]));
   }
 
   /*

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -8,13 +8,14 @@
 
 #define _GNU_SOURCE // for GNU basename()
 
-#include "cpu.h"      // for get_online_cpu_set(), parse_cpu_list(),
-                      //     parse_cpu_mask()
-#include "ring_set.h" // for for_each_ring_in_size(), RING_CLR(), RING_COUNT(),
-                      //     RING_ISSET(), RING_SET()
-#include "rxtx.h"     // for for_each_set_ring(), program_basename, rxtx_args,
-                      //     rxtx_desc, rxtx_close(), rxtx_loop(), rxtx_open()
-#include "sig.h"      // for setup_signals()
+#include "cpu.h"       // for get_online_cpu_set(), parse_cpu_list(),
+                       //     parse_cpu_mask()
+#include "ring_set.h"  // for for_each_ring_in_size(), RING_CLR(),
+                       //     RING_COUNT(), RING_ISSET(), RING_SET()
+#include "rxtx.h"      // for for_each_set_ring(), program_basename, rxtx_args,
+                       //     rxtx_desc, rxtx_close(), rxtx_loop(), rxtx_open()
+#include "rxtx_ring.h" // for rxtx_ring_get_packets_received()
+#include "sig.h"       // for setup_signals()
 
 #include <linux/if_packet.h> // for PACKET_FANOUT_CPU
 
@@ -413,7 +414,7 @@ int main(int argc, char **argv) {
   for_each_set_ring(i, &rtd) {
     pthread_join(threads[i], NULL);
     fprintf(out, "%ju packets captured on cpu%d.\n",
-                                      rtd.rings[i].stats->packets_received, i);
+                           rxtx_ring_get_packets_received(&(rtd.rings[i])), i);
   }
 
   pthread_attr_destroy(&attr);

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -13,7 +13,9 @@
 #include "ring_set.h"  // for for_each_ring_in_size(), RING_CLR(),
                        //     RING_COUNT(), RING_ISSET(), RING_SET()
 #include "rxtx.h"      // for for_each_set_ring(), program_basename, rxtx_args,
-                       //     rxtx_desc, rxtx_close(), rxtx_loop(), rxtx_open()
+                       //     rxtx_desc, rxtx_close(),
+                       //     rxtx_get_packets_received(), rxtx_loop(),
+                       //     rxtx_open()
 #include "rxtx_ring.h" // for rxtx_ring_get_packets_received()
 #include "sig.h"       // for setup_signals()
 
@@ -419,7 +421,8 @@ int main(int argc, char **argv) {
 
   pthread_attr_destroy(&attr);
 
-  fprintf(out, "%ju packets captured total.\n", rtd.stats->packets_received);
+  fprintf(out, "%ju packets captured total.\n",
+                                              rxtx_get_packets_received(&rtd));
 
   rxtx_close(&rtd);
 

--- a/tests/rxtx_stats/test__rxtx_stats_increment_packets_received__pthread_mutex_lock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_packets_received__pthread_mutex_lock__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == 0);

--- a/tests/rxtx_stats/test__rxtx_stats_increment_packets_received__pthread_mutex_unlock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_packets_received__pthread_mutex_unlock__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == 0);

--- a/tests/rxtx_stats/test__rxtx_stats_increment_packets_unreliable__pthread_mutex_lock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_packets_unreliable__pthread_mutex_lock__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == 0);

--- a/tests/rxtx_stats/test__rxtx_stats_increment_packets_unreliable__pthread_mutex_unlock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_packets_unreliable__pthread_mutex_unlock__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == 0);

--- a/tests/rxtx_stats/test__rxtx_stats_increment_tp_drops__pthread_mutex_lock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_tp_drops__pthread_mutex_lock__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == 0);

--- a/tests/rxtx_stats/test__rxtx_stats_increment_tp_drops__pthread_mutex_unlock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_tp_drops__pthread_mutex_unlock__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == 0);

--- a/tests/rxtx_stats/test__rxtx_stats_increment_tp_packets__pthread_mutex_lock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_tp_packets__pthread_mutex_lock__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == 0);

--- a/tests/rxtx_stats/test__rxtx_stats_increment_tp_packets__pthread_mutex_unlock__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_increment_tp_packets__pthread_mutex_unlock__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == 0);

--- a/tests/rxtx_stats/test__rxtx_stats_mutex_destroy__pthread_mutex_destroy__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_mutex_destroy__pthread_mutex_destroy__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == 0);

--- a/tests/rxtx_stats/test__rxtx_stats_mutex_init__calloc__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_mutex_init__calloc__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == -1);

--- a/tests/rxtx_stats/test__rxtx_stats_mutex_init__pthread_mutex_init__failure.c
+++ b/tests/rxtx_stats/test__rxtx_stats_mutex_init__pthread_mutex_init__failure.c
@@ -18,8 +18,7 @@ int main(void) {
   char errbuf[RXTX_ERRBUF_SIZE];
   int status;
 
-  status = rxtx_stats_init(&rts, errbuf);
-  assert(status == 0);
+  rxtx_stats_init(&rts, errbuf);
 
   status = rxtx_stats_mutex_init(&rts);
   assert(status == -1);


### PR DESCRIPTION
Improvements and reorganization.
* A couple fixes for `rxtx_stats_{init,destroy}()`.
* Add a number of functions improving readability and abstraction.
* Move `rxtx_loop()` to `rxtx_ring_loop()`.
* Separate packet retrieval logic from `rxtx_ring_loop()` into `rxtx_ring_next_packet()`.
* Start abstracting remaining `rxtx_ring_loop()` logic from rxtx_ring (this will move to rxtx_capture once that concept is introduced).