### PR TITLE
Improvements and reorganization 2.

### DIFF
--- a/rxtx.c
+++ b/rxtx.c
@@ -47,6 +47,8 @@ volatile sig_atomic_t rxtx_breakloop = 0;
 static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
   int i, status;
 
+  p->errbuf = errbuf;
+
   p->args = args;
   p->rings = calloc(args->ring_count, sizeof(*p->rings));
   p->stats = calloc(1, sizeof(*p->stats));
@@ -189,6 +191,8 @@ static void rxtx_desc_destroy(struct rxtx_desc *p) {
   free(p->rings);
   p->rings = NULL;
   p->args = NULL;
+
+  p->errbuf = NULL;
 }
 
 /* ========================================================================= */

--- a/rxtx.c
+++ b/rxtx.c
@@ -254,6 +254,11 @@ int rxtx_get_initialized_ring_count(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+uintmax_t rxtx_get_packet_count(struct rxtx_desc *p) {
+  return p->args->packet_count;
+}
+
+/* ========================================================================= */
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p) {
   return rxtx_stats_get_packets_received(p->stats);
 }

--- a/rxtx.c
+++ b/rxtx.c
@@ -12,7 +12,7 @@
 
 #include "rxtx.h"
 
-#include "rxtx_error.h" // for RXTX_ERRBUF_SIZE, RXTX_ERROR
+#include "rxtx_error.h" // for RXTX_ERROR, rxtx_fill_errbuf()
 #include "rxtx_ring.h" // for rxtx_ring_destroy(), rxtx_ring_init(),
                        //     rxtx_ring_mark_packets_in_buffer_as_unreliable(),
                        //     rxtx_ring_savefile_open()
@@ -24,71 +24,128 @@
                         //     rxtx_stats_init_with_mutex()
 
 #include "interface.h" // for interface_set_promisc_on()
+#include "ring_set.h"  // for RING_COUNT(), RING_ISSET(), RING_SET(),
+                       //     RING_SETSIZE, RING_ZERO()
 #include "sig.h"       // for keep_running
 
-#include <net/if.h>     // for if_nametoindex()
+#include <net/if.h>     // for if_indextoname(), if_nametoindex(), IF_NAMESIZE
 #include <sys/socket.h> // for setsockopt()
 
+#include <assert.h> // for assert()
+#include <errno.h>  // for errno
+#include <pcap.h>   // for PCAP_D_IN, PCAP_D_INOUT, PCAP_D_OUT
 #include <stdio.h>  // for fprintf(), NULL, stderr
-#include <stdlib.h> // for calloc(), exit(), free()
+#include <stdlib.h> // for calloc(), free()
+#include <string.h> // for memcpy(), strdup(), strerror(), strlen()
 #include <unistd.h> // for getpid()
-
-#define EXIT_FAIL 1
 
 #define INCREMENT_STEP 1
 
-char errbuf[RXTX_ERRBUF_SIZE] = "";
+#define RXTX_INACTIVE 0
+#define RXTX_ACTIVATING 1
+#define RXTX_ACTIVE 2
+
 char *program_basename = NULL;
 
 volatile sig_atomic_t rxtx_breakloop = 0;
 
 /* ========================================================================= */
-static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
-  int i, status;
-
+void rxtx_init(struct rxtx_desc *p, char *errbuf) {
   p->errbuf = errbuf;
 
-  p->args = args;
-  p->rings = calloc(args->ring_count, sizeof(*p->rings));
-  p->stats = calloc(1, sizeof(*p->stats));
+  p->ifname            = NULL;
+  p->rings             = NULL;
+  p->savefile_template = NULL;
+  p->stats             = NULL;
 
-  status = rxtx_stats_init_with_mutex(p->stats, errbuf);
-  if (status == RXTX_ERROR) {
-    fprintf(stderr, "%s: %s\n", program_basename, errbuf);
-    exit(EXIT_FAIL);
+  p->breakloop       = 0;
+  p->direction       = PCAP_D_INOUT;
+  p->fanout_group_id = getpid() & 0xffff;
+  p->fanout_mode     = 0;
+  p->ifindex         = 0;
+  p->initialized_ring_count = 0;
+  p->is_active       = RXTX_INACTIVE;
+  p->packet_buffered = 0;
+  p->packet_count    = 0;
+  p->promiscuous     = 0;
+  p->ring_count      = 0;
+  p->verbose         = 0;
+
+  RING_ZERO(&(p->ring_set));
+}
+
+/* ========================================================================= */
+int rxtx_activate(struct rxtx_desc *p) {
+  int i, status;
+
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error activating descriptor: descriptor is"
+                                                            " already active");
+    return RXTX_ERROR;
   }
 
-  p->ifindex = 0;
-  p->fanout_group_id = 0;
-  p->breakloop = 0;
+  p->is_active = RXTX_ACTIVATING;
 
-  /*
-   * If we were supplied an ifname, we need to lookup the ifindex. Otherwise,
-   * we want ifindex to be 0 to match any interface.
-   *
-   * When an ifindex lookup is needed, we want the ifindex before entering our
-   * ring init loop and do not yet have a socket fd. It's more clear to create,
-   * use, and discard a temporary socket fd for our SIOCGIFINDEX ioctl request
-   * than to try to use one of the socket fds we'll create later.
-   *
-   * if_nametoindex() does exactly what we want.
-   */
-  if (args->ifname) {
-    p->ifindex = if_nametoindex(args->ifname);
+  if (rxtx_breakloop_isset(p)) {
+    rxtx_fill_errbuf(p->errbuf, "error activating descriptor: global breakloop"
+                                                                    " is set");
+    return RXTX_ERROR;
+  }
 
+  if (p->verbose) {
+    char direction_str[5] = "rxtx";
+    if (p->direction == PCAP_D_IN) {
+      strcpy(direction_str, "rx");
+    } else if (p->direction == PCAP_D_OUT) {
+      strcpy(direction_str, "tx");
+    }
+    fprintf(stderr, "using direction '%s'\n", direction_str);
+  }
+
+  if (p->verbose) {
+    fprintf(stderr, "using fanout group id '%i'\n", p->fanout_group_id);
+  }
+
+  if (!p->fanout_mode) {
+    rxtx_fill_errbuf(p->errbuf, "error activating descriptor: fanout mode is"
+                                                       " required, but unset");
+    return RXTX_ERROR;
+  }
+
+  if (p->verbose) {
+    fprintf(stderr, "using fanout mode '%i'\n", p->fanout_mode);
+  }
+
+  if (p->verbose) {
     if (!p->ifindex) {
-      fprintf(stderr, "%s: Failed to get ifindex for interface '%s'\n",
-                                               program_basename, args->ifname);
-      exit(EXIT_FAIL);
+      fprintf(stderr, "using ifindex '%u' for any interface\n", p->ifindex);
+    } else {
+      fprintf(stderr, "using ifindex '%u' for interface '%s'\n", p->ifindex,
+                                                                    p->ifname);
     }
   }
 
-  if (args->verbose) {
-    if (p->ifindex == 0) {
-      fprintf(stderr, "Using ifindex '%u' for any interface.\n", p->ifindex);
+  if (p->verbose) {
+    if (p->packet_buffered) {
+      fprintf(stderr, "packet buffered output requested\n");
     } else {
-      fprintf(stderr, "Using ifindex '%u' for interface '%s'.\n", p->ifindex,
-                                                                 args->ifname);
+      fprintf(stderr, "packet buffered output unwanted\n");
+    }
+  }
+
+  if (p->verbose) {
+    if (!p->packet_count) {
+      fprintf(stderr, "using packet count '0' (infinite)\n");
+    } else {
+      fprintf(stderr, "using packet count '%ju'\n", p->packet_count);
+    }
+  }
+
+  if (p->verbose) {
+    if (p->promiscuous) {
+      fprintf(stderr, "promiscuous mode requested\n");
+    } else {
+      fprintf(stderr, "promiscuous mode unwanted\n");
     }
   }
 
@@ -96,42 +153,98 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
    * We only have to enable promiscuity once and it will stick around for the
    * duration of the process.
    */
-  if (args->promiscuous) {
+  if (p->promiscuous) {
     if (p->ifindex == 0) {
-      if (args->verbose) {
-        fprintf(stderr, "Skipping promiscuous mode for ifindex '%u' (any"
-                                                 " interface).\n", p->ifindex);
+      if (p->verbose) {
+        fprintf(stderr, "skipping promiscuous mode for ifindex '%u' (any"
+                                                  " interface)\n", p->ifindex);
       }
     } else {
       status = interface_set_promisc_on(p->ifindex);
       if (status == -1) {
-        fprintf(stderr, "%s: Failed to enable promiscuous mode for ifindex"
-                                     " '%u'.\n", program_basename, p->ifindex);
-        exit(EXIT_FAIL);
+        rxtx_fill_errbuf(p->errbuf, "error activating descriptor: failed to"
+                      " enable promiscuous mode for ifindex '%u'", p->ifindex);
+        return RXTX_ERROR;
       }
     }
   }
 
-  /*
-   * We need an id to add socket fds to our fanout group.
-   */
-  p->fanout_group_id = getpid() & 0xffff;
-
-  if (args->verbose) {
-    fprintf(stderr, "Generated fanout group id '%d'.\n", p->fanout_group_id);
+  if (!p->ring_count) {
+    rxtx_fill_errbuf(p->errbuf, "error activating descriptor: ring count of"
+                                      " one or more is required, but is zero");
+    return RXTX_ERROR;
   }
 
-  p->initialized_ring_count = 0;
+  if (p->verbose) {
+    fprintf(stderr, "using ring count '%i'\n", p->ring_count);
+  }
+
+  if (p->verbose) {
+    fprintf(stderr, "verbose output requested\n");
+  }
+
+  if (!RING_COUNT(&(p->ring_set))) {
+    for_each_ring(i, p) {
+      RING_SET(i, &(p->ring_set));
+    }
+  }
+
+  /* TODO: Compress this into standard cpulist format. */
+  if (p->verbose) {
+    int count = RING_COUNT(&(p->ring_set));
+    fprintf(stderr, "using ring set '");
+    status = 0;
+    for (i = 0; i < RING_SETSIZE; i++) {
+      if (RING_ISSET(i, &(p->ring_set))) {
+        fprintf(stderr, "%i", i);
+        status++;
+        if ((status) < count) {
+          fprintf(stderr, ",");
+        }
+      }
+    }
+    fprintf(stderr, "'\n");
+  }
+
+  status = 0;
+  for_each_ring(i, p) {
+    if (RING_ISSET(i, &(p->ring_set))) {
+      status++;
+    }
+  }
+  if (!status) {
+    rxtx_fill_errbuf(p->errbuf, "error activating descriptor: ring set"
+                                       " contains only out-of-bounds members");
+    return RXTX_ERROR;
+  }
+
+  p->stats = calloc(1, sizeof(*p->stats));
+  if (!p->stats) {
+    rxtx_fill_errbuf(p->errbuf, "error activating descriptor: %s",
+                                                              strerror(errno));
+    return RXTX_ERROR;
+  }
+
+  status = rxtx_stats_init_with_mutex(p->stats, p->errbuf);
+  if (status == RXTX_ERROR) {
+    return RXTX_ERROR;
+  }
+
+  p->rings = calloc(p->ring_count, sizeof(*p->rings));
+  if (!p->rings) {
+    rxtx_fill_errbuf(p->errbuf, "error activating descriptor: %s",
+                                                              strerror(errno));
+    return RXTX_ERROR;
+  }
 
   /*
    * This loop creates our rings, including per-ring socket fds. We need the
    * instantiation order to follow ring index order.
    */
   for_each_ring(i, p) {
-    status = rxtx_ring_init(&(p->rings[i]), p, errbuf);
+    status = rxtx_ring_init(&(p->rings[i]), p, p->errbuf);
     if (status == RXTX_ERROR) {
-      fprintf(stderr, "%s: %s\n", program_basename, errbuf);
-      exit(EXIT_FAIL);
+      return RXTX_ERROR;
     }
   }
 
@@ -150,8 +263,7 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
   for_each_set_ring(i, p) {
     status = rxtx_ring_mark_packets_in_buffer_as_unreliable(&(p->rings[i]));
     if (status == RXTX_ERROR) {
-      fprintf(stderr, "%s: %s\n", program_basename, errbuf);
-      exit(EXIT_FAIL);
+      return RXTX_ERROR;
     }
   }
 
@@ -159,20 +271,16 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
    * Open savefiles only for rings on which we're capturing.
    */
   for_each_set_ring(i, p) {
-    if (args->savefile_template) {
-      status = rxtx_ring_savefile_open(&(p->rings[i]),
-                                                      args->savefile_template);
+    if (p->savefile_template) {
+      status = rxtx_ring_savefile_open(&(p->rings[i]), p->savefile_template);
       if (status == RXTX_ERROR) {
-        fprintf(stderr, "%s: %s\n", program_basename, errbuf);
-        exit(EXIT_FAIL);
+        return RXTX_ERROR;
       }
     }
   }
-}
 
-/* ========================================================================= */
-int rxtx_open(struct rxtx_desc *p, struct rxtx_args *args) {
-  rxtx_desc_init(p, args);
+  p->is_active = RXTX_ACTIVE;
+
   return 0;
 }
 
@@ -180,9 +288,21 @@ int rxtx_open(struct rxtx_desc *p, struct rxtx_args *args) {
 int rxtx_close(struct rxtx_desc *p) {
   int i, status;
 
+  p->is_active = 0;
   p->breakloop = 0;
   p->fanout_group_id = 0;
   p->ifindex = 0;
+  p->initialized_ring_count = 0;
+
+  if (p->savefile_template) {
+    free(p->savefile_template);
+  }
+  p->savefile_template = NULL;
+
+  if (p->ifname) {
+    free(p->ifname);
+  }
+  p->ifname = NULL;
 
   status = rxtx_stats_destroy_with_mutex(p->stats);
   if (status == RXTX_ERROR) {
@@ -202,7 +322,6 @@ int rxtx_close(struct rxtx_desc *p) {
   free(p->rings);
   p->rings = NULL;
 
-  p->args = NULL;
   p->errbuf = NULL;
 
   return 0;
@@ -219,12 +338,13 @@ int rxtx_breakloop_isset(struct rxtx_desc *p) {
 
 /* ========================================================================= */
 pcap_direction_t rxtx_get_direction(struct rxtx_desc *p) {
-  return p->args->direction;
+  return p->direction;
 }
 
 /* ========================================================================= */
 int rxtx_get_fanout_arg(struct rxtx_desc *p) {
-  return p->fanout_group_id | (p->args->fanout_mode << 16);
+  assert((p->fanout_group_id >> 16) == 0);
+  return p->fanout_group_id | (p->fanout_mode << 16);
 }
 
 /* ========================================================================= */
@@ -234,8 +354,8 @@ int rxtx_get_fanout_group_id(struct rxtx_desc *p) {
 
 /* ========================================================================= */
 int rxtx_get_fanout_mode(struct rxtx_desc *p) {
-  return p->args->fanout_mode;
- }
+  return p->fanout_mode;
+}
 
 /* ========================================================================= */
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p) {
@@ -244,7 +364,7 @@ unsigned int rxtx_get_ifindex(struct rxtx_desc *p) {
 
 /* ========================================================================= */
 const char *rxtx_get_ifname(struct rxtx_desc *p) {
-  return p->args->ifname;
+  return p->ifname;
 }
 
 /* ========================================================================= */
@@ -254,7 +374,7 @@ int rxtx_get_initialized_ring_count(struct rxtx_desc *p) {
 
 /* ========================================================================= */
 uintmax_t rxtx_get_packet_count(struct rxtx_desc *p) {
-  return p->args->packet_count;
+  return p->packet_count;
 }
 
 /* ========================================================================= */
@@ -263,32 +383,51 @@ uintmax_t rxtx_get_packets_received(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+struct rxtx_ring *rxtx_get_ring(struct rxtx_desc *p, unsigned int idx) {
+  if (p->is_active != RXTX_ACTIVE) {
+    rxtx_fill_errbuf(p->errbuf, "error getting ring: ring access on an"
+                        " inactive or activating descriptor is not permitted");
+    return NULL;
+  }
+
+  assert(p->ring_count == p->initialized_ring_count);
+
+  if (idx >= p->ring_count) {
+    rxtx_fill_errbuf(p->errbuf, "error getting ring: ring idx '%u' is"
+                                                        " out-of-bounds", idx);
+    return NULL;
+  }
+
+  return &(p->rings[idx]);
+}
+
+/* ========================================================================= */
 int rxtx_get_ring_count(struct rxtx_desc *p) {
-  return p->args->ring_count;
+  return p->ring_count;
 }
 
 /* ========================================================================= */
 const ring_set_t *rxtx_get_ring_set(struct rxtx_desc *p) {
-  return &(p->args->ring_set);
+  return &(p->ring_set);
 }
 
 /* ========================================================================= */
 const char *rxtx_get_savefile_template(struct rxtx_desc *p) {
-  return p->args->savefile_template;
+  return p->savefile_template;
 }
 
 /* ========================================================================= */
 int rxtx_packet_buffered_isset(struct rxtx_desc *p) {
-  return p->args->packet_buffered;
+  return p->packet_buffered;
 }
 
 /* ========================================================================= */
 int rxtx_packet_count_reached(struct rxtx_desc *p) {
-  if (!p->args->packet_count) {
+  if (!p->packet_count) {
     return 0;
   }
 
-  if (rxtx_stats_get_packets_received(p->stats) < p->args->packet_count) {
+  if (rxtx_stats_get_packets_received(p->stats) < p->packet_count) {
     return 0;
   }
 
@@ -297,24 +436,50 @@ int rxtx_packet_count_reached(struct rxtx_desc *p) {
 
 /* ========================================================================= */
 int rxtx_promiscuous_isset(struct rxtx_desc *p) {
-  return p->args->promiscuous;
+  return p->promiscuous;
 }
 
 /* ========================================================================= */
 int rxtx_verbose_isset(struct rxtx_desc *p) {
-  return p->args->verbose;
+  return p->verbose;
 }
 /* ----------------------------- end of getters ---------------------------- */
 
 /* ---------------------------- start of setters --------------------------- */
 /* ========================================================================= */
-void rxtx_increment_initialized_ring_count(struct rxtx_desc *p) {
+int rxtx_increment_initialized_ring_count(struct rxtx_desc *p) {
+  /* p->is_active must be RXTX_ACTIVATING */
+
+  if (p->is_active == RXTX_INACTIVE) {
+    rxtx_fill_errbuf(p->errbuf, "error incrementing initialized ring count:"
+            " changing initialized ring count on an inactive descriptor is not"
+                                                                 " permitted");
+    return RXTX_ERROR;
+  }
+
+  if (p->is_active == RXTX_ACTIVE) {
+    rxtx_fill_errbuf(p->errbuf, "error incrementing initialized ring count:"
+              " changing initialized ring count on an active descriptor is not"
+                                                                 " permitted");
+    return RXTX_ERROR;
+  }
+
   p->initialized_ring_count++;
+
+  return 0;
 }
 
 /* ========================================================================= */
 int rxtx_increment_packets_received(struct rxtx_desc *p) {
-  int status = rxtx_stats_increment_packets_received(p->stats, INCREMENT_STEP);
+  int status = 0;
+
+  if (!p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error incrementing packets received: changing"
+               " packets received on an inactive descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  status = rxtx_stats_increment_packets_received(p->stats, INCREMENT_STEP);
   if (status == RXTX_ERROR) {
     return RXTX_ERROR;
   }
@@ -323,12 +488,253 @@ int rxtx_increment_packets_received(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
-void rxtx_set_breakloop(struct rxtx_desc *p) {
+int rxtx_set_breakloop(struct rxtx_desc *p) {
+  if (!p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting breakloop: setting breakloop on"
+                                   " an inactive descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
   p->breakloop++;
+
+  return 0;
 }
 
 /* ========================================================================= */
 void rxtx_set_breakloop_global(void) {
   rxtx_breakloop = 1;
+}
+
+/* ========================================================================= */
+int rxtx_set_direction(struct rxtx_desc *p, pcap_direction_t direction) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting direction: changing direction"
+                                  " on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  p->direction = direction;
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_fanout_group_id(struct rxtx_desc *p, int group_id) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting fanout group id: changing"
+                  " fanout group id on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  p->fanout_group_id = group_id & 0xffff;
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_fanout_mode(struct rxtx_desc *p, int mode) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting fanout mode: changing fanout"
+                             " mode on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  p->fanout_mode = mode;
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_ifindex(struct rxtx_desc *p, unsigned int ifindex) {
+  char ifname[IF_NAMESIZE] = "";
+
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting ifindex: changing ifindex on an"
+                                        " active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  if (p->ifname) {
+    free(p->ifname);
+  }
+
+  if (!ifindex) {
+    p->ifindex = 0;
+    p->ifname = NULL;
+  } else {
+    p->ifindex = ifindex;
+    if_indextoname(ifindex, ifname);
+    if (!strlen(ifname)) {
+      rxtx_fill_errbuf(p->errbuf, "error setting ifindex '%u': %s", ifindex,
+                                                              strerror(errno));
+      return RXTX_ERROR;
+    }
+
+    p->ifname = strdup(ifname);
+    if (!p->ifname) {
+      rxtx_fill_errbuf(p->errbuf, "error setting ifindex '%u': %s", ifindex,
+                                                              strerror(errno));
+      return RXTX_ERROR;
+    }
+  }
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_ifname(struct rxtx_desc *p, const char *ifname) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting ifname: changing ifname on an"
+                                        " active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  if (p->ifname) {
+    free(p->ifname);
+  }
+
+  if (!ifname) {
+    p->ifname = NULL;
+    p->ifindex = 0;
+  } else {
+    p->ifname = strdup(ifname);
+    if (!p->ifname) {
+      rxtx_fill_errbuf(p->errbuf, "error setting ifname '%s': %s", ifname,
+                                                              strerror(errno));
+      return RXTX_ERROR;
+    }
+
+    p->ifindex = if_nametoindex(ifname);
+    if (!p->ifindex) {
+      rxtx_fill_errbuf(p->errbuf, "error setting ifname '%s': %s", ifname,
+                                                              strerror(errno));
+      return RXTX_ERROR;
+    }
+  }
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_packet_count(struct rxtx_desc *p, uintmax_t count) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting packet count: changing packet"
+                            " count on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  p->packet_count = count;
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_ring_count(struct rxtx_desc *p, unsigned int count) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting ring count: changing ring"
+                            " count on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  p->ring_count = count;
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_ring_set(struct rxtx_desc *p, const ring_set_t *set) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting ring set: changing ring set on"
+                                     " an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  memcpy(&(p->ring_set), set, sizeof(p->ring_set));
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_savefile_template(struct rxtx_desc *p, const char *template) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting savefile template: changing"
+                " savefile template on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  if (!template) {
+    p->savefile_template = NULL;
+  } else {
+    p->savefile_template = strdup(template);
+    if (!p->savefile_template) {
+      rxtx_fill_errbuf(p->errbuf, "error setting savefile template '%s': %s",
+                                                    template, strerror(errno));
+      return RXTX_ERROR;
+    }
+  }
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_packet_buffered(struct rxtx_desc *p) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting packet buffered: changing"
+                  " packet buffered on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  p->packet_buffered = 1;
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_set_promiscuous(struct rxtx_desc *p) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error setting promiscuous: changing"
+                      " promiscuous on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  p->promiscuous = 1;
+
+  return 0;
+}
+
+/* ========================================================================= */
+void rxtx_set_verbose(struct rxtx_desc *p) {
+  p->verbose = 1;
+}
+
+/* ========================================================================= */
+int rxtx_unset_packet_buffered(struct rxtx_desc *p) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error unsetting packet buffered: changing"
+                  " packet buffered on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  p->packet_buffered = 0;
+
+  return 0;
+}
+
+/* ========================================================================= */
+int rxtx_unset_promiscuous(struct rxtx_desc *p) {
+  if (p->is_active) {
+    rxtx_fill_errbuf(p->errbuf, "error unsetting promiscuous: changing"
+                      " promiscuous on an active descriptor is not permitted");
+    return RXTX_ERROR;
+  }
+
+  p->promiscuous = 0;
+
+  return 0;
+}
+
+/* ========================================================================= */
+void rxtx_unset_verbose(struct rxtx_desc *p) {
+  p->verbose = 0;
 }
 /* ----------------------------- end of setters ---------------------------- */

--- a/rxtx.c
+++ b/rxtx.c
@@ -264,6 +264,11 @@ uintmax_t rxtx_get_packets_received(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+int rxtx_get_ring_count(struct rxtx_desc *p) {
+  return p->args->ring_count;
+}
+
+/* ========================================================================= */
 int rxtx_packet_buffered_isset(struct rxtx_desc *p) {
   return p->args->packet_buffered;
 }

--- a/rxtx.c
+++ b/rxtx.c
@@ -244,6 +244,11 @@ unsigned int rxtx_get_ifindex(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+const char *rxtx_get_ifname(struct rxtx_desc *p) {
+  return p->args->ifname;
+}
+
+/* ========================================================================= */
 int rxtx_get_initialized_ring_count(struct rxtx_desc *p) {
   return p->initialized_ring_count;
 }

--- a/rxtx.c
+++ b/rxtx.c
@@ -29,7 +29,6 @@
 #include <net/if.h>     // for if_nametoindex()
 #include <sys/socket.h> // for setsockopt()
 
-#include <sched.h>  // for sched_getcpu()
 #include <stdio.h>  // for fprintf(), NULL, stderr
 #include <stdlib.h> // for calloc(), exit(), free()
 #include <unistd.h> // for getpid()

--- a/rxtx.c
+++ b/rxtx.c
@@ -272,6 +272,11 @@ int rxtx_packet_count_reached(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+int rxtx_promiscuous_isset(struct rxtx_desc *p) {
+  return p->args->promiscuous;
+}
+
+/* ========================================================================= */
 int rxtx_verbose_isset(struct rxtx_desc *p) {
   return p->args->verbose;
 }

--- a/rxtx.c
+++ b/rxtx.c
@@ -274,6 +274,11 @@ const ring_set_t *rxtx_get_ring_set(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+const char *rxtx_get_savefile_template(struct rxtx_desc *p) {
+  return p->args->savefile_template;
+}
+
+/* ========================================================================= */
 int rxtx_packet_buffered_isset(struct rxtx_desc *p) {
   return p->args->packet_buffered;
 }

--- a/rxtx.c
+++ b/rxtx.c
@@ -229,6 +229,16 @@ int rxtx_get_fanout_arg(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+int rxtx_get_fanout_group_id(struct rxtx_desc *p) {
+  return p->fanout_group_id;
+}
+
+/* ========================================================================= */
+int rxtx_get_fanout_mode(struct rxtx_desc *p) {
+  return p->args->fanout_mode;
+ }
+
+/* ========================================================================= */
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p) {
   return p->ifindex;
 }

--- a/rxtx.c
+++ b/rxtx.c
@@ -269,6 +269,11 @@ int rxtx_get_ring_count(struct rxtx_desc *p) {
 }
 
 /* ========================================================================= */
+const ring_set_t *rxtx_get_ring_set(struct rxtx_desc *p) {
+  return &(p->args->ring_set);
+}
+
+/* ========================================================================= */
 int rxtx_packet_buffered_isset(struct rxtx_desc *p) {
   return p->args->packet_buffered;
 }

--- a/rxtx.c
+++ b/rxtx.c
@@ -172,8 +172,8 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
 }
 
 /* ========================================================================= */
-int rxtx_open(struct rxtx_desc *rtd, struct rxtx_args *args) {
-  rxtx_desc_init(rtd, args);
+int rxtx_open(struct rxtx_desc *p, struct rxtx_args *args) {
+  rxtx_desc_init(p, args);
   return 0;
 }
 

--- a/rxtx.c
+++ b/rxtx.c
@@ -172,41 +172,42 @@ static void rxtx_desc_init(struct rxtx_desc *p, struct rxtx_args *args) {
 }
 
 /* ========================================================================= */
-static void rxtx_desc_destroy(struct rxtx_desc *p) {
-  int i, status;
-
-  p->breakloop = 0;
-  p->fanout_group_id = 0;
-  p->ifindex = 0;
-  rxtx_stats_destroy_with_mutex(p->stats);
-  free(p->stats);
-  p->stats = NULL;
-  for_each_ring(i, p) {
-    status = rxtx_ring_destroy(&(p->rings[i]));
-    if (status == RXTX_ERROR) {
-      fprintf(stderr, "%s: %s\n", program_basename, errbuf);
-      exit(EXIT_FAIL);
-    }
-  }
-  free(p->rings);
-  p->rings = NULL;
-  p->args = NULL;
-
-  p->errbuf = NULL;
-}
-
-/* ========================================================================= */
 int rxtx_open(struct rxtx_desc *rtd, struct rxtx_args *args) {
   rxtx_desc_init(rtd, args);
   return 0;
 }
 
 /* ========================================================================= */
-int rxtx_close(struct rxtx_desc *rtd) {
-  rxtx_desc_destroy(rtd);
+int rxtx_close(struct rxtx_desc *p) {
+  int i, status;
+
+  p->breakloop = 0;
+  p->fanout_group_id = 0;
+  p->ifindex = 0;
+
+  status = rxtx_stats_destroy_with_mutex(p->stats);
+  if (status == RXTX_ERROR) {
+    return RXTX_ERROR;
+  }
+
+  free(p->stats);
+  p->stats = NULL;
+
+  for_each_ring(i, p) {
+    status = rxtx_ring_destroy(&(p->rings[i]));
+    if (status == RXTX_ERROR) {
+      return RXTX_ERROR;
+    }
+  }
+
+  free(p->rings);
+  p->rings = NULL;
+
+  p->args = NULL;
+  p->errbuf = NULL;
+
   return 0;
 }
-
 
 /* ---------------------------- start of getters --------------------------- */
 /* ========================================================================= */

--- a/rxtx.h
+++ b/rxtx.h
@@ -74,6 +74,7 @@ int rxtx_get_initialized_ring_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
 int rxtx_packet_buffered_isset(struct rxtx_desc *p);
 int rxtx_packet_count_reached(struct rxtx_desc *p);
+int rxtx_promiscuous_isset(struct rxtx_desc *p);
 int rxtx_verbose_isset(struct rxtx_desc *p);
 
 void rxtx_increment_initialized_ring_count(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -61,20 +61,20 @@ struct rxtx_desc {
   char              *errbuf;
 };
 
-int rxtx_open(struct rxtx_desc *rtd, struct rxtx_args *args);
+int rxtx_open(struct rxtx_desc *p, struct rxtx_args *args);
 int rxtx_close(struct rxtx_desc *p);
 
 int rxtx_breakloop_isset(struct rxtx_desc *p);
 pcap_direction_t rxtx_get_direction(struct rxtx_desc *p);
 int rxtx_get_fanout_arg(struct rxtx_desc *p);
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p);
-int rxtx_get_initialized_ring_count(struct rxtx_desc *rtd);
+int rxtx_get_initialized_ring_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
 int rxtx_packet_buffered_isset(struct rxtx_desc *p);
 int rxtx_packet_count_reached(struct rxtx_desc *p);
 int rxtx_verbose_isset(struct rxtx_desc *p);
 
-void rxtx_increment_initialized_ring_count(struct rxtx_desc *rtd);
+void rxtx_increment_initialized_ring_count(struct rxtx_desc *p);
 int rxtx_increment_packets_received(struct rxtx_desc *p);
 void rxtx_set_breakloop(struct rxtx_desc *p);
 void rxtx_set_breakloop_global(void);

--- a/rxtx.h
+++ b/rxtx.h
@@ -67,6 +67,8 @@ int rxtx_close(struct rxtx_desc *p);
 int rxtx_breakloop_isset(struct rxtx_desc *p);
 pcap_direction_t rxtx_get_direction(struct rxtx_desc *p);
 int rxtx_get_fanout_arg(struct rxtx_desc *p);
+int rxtx_get_fanout_group_id(struct rxtx_desc *p);
+int rxtx_get_fanout_mode(struct rxtx_desc *p);
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -72,6 +72,7 @@ int rxtx_get_fanout_mode(struct rxtx_desc *p);
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p);
 const char *rxtx_get_ifname(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *p);
+uintmax_t rxtx_get_packet_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
 int rxtx_packet_buffered_isset(struct rxtx_desc *p);
 int rxtx_packet_count_reached(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -28,40 +28,40 @@ struct rxtx_ring;
 #include <stdint.h>  // for uintmax_t
 
 #define for_each_ring(ring, rtd) \
-  for_each_ring_in_size((ring), (rtd)->args->ring_count)
+  for_each_ring_in_size((ring), (rtd)->ring_count)
 
 #define for_each_set_ring(ring, rtd) \
-  for_each_set_ring_in_size((ring), &((rtd)->args->ring_set), \
-                                                       (rtd)->args->ring_count)
+  for_each_set_ring_in_size((ring), &((rtd)->ring_set), (rtd)->ring_count)
 
 extern char *program_basename;
 extern volatile sig_atomic_t rxtx_breakloop;
 
-struct rxtx_args {
-  pcap_direction_t direction;
-  char      *ifname;
-  int       fanout_mode;
-  char      *savefile_template;
-  uintmax_t packet_count;
-  int       ring_count;
-  cpu_set_t ring_set;
-  bool      packet_buffered;
-  bool      promiscuous;
-  bool      verbose;
-};
-
 struct rxtx_desc {
-  struct rxtx_args  *args;
   struct rxtx_ring  *rings;
   struct rxtx_stats *stats;
-  unsigned int      ifindex;
-  int               fanout_group_id;
-  int               initialized_ring_count;
-  int               breakloop;
-  char              *errbuf;
+
+  char *ifname;
+  char *savefile_template;
+
+  int              breakloop;
+  pcap_direction_t direction;
+  int              fanout_group_id;
+  int              fanout_mode;
+  unsigned int     ifindex;
+  int              initialized_ring_count;
+  int              is_active;
+  uintmax_t        packet_count;
+  int              ring_count;
+  cpu_set_t        ring_set;
+  int              packet_buffered;
+  int              promiscuous;
+  int              verbose;
+
+  char *errbuf;
 };
 
-int rxtx_open(struct rxtx_desc *p, struct rxtx_args *args);
+void rxtx_init(struct rxtx_desc *p, char *errbuf);
+int rxtx_activate(struct rxtx_desc *p);
 int rxtx_close(struct rxtx_desc *p);
 
 int rxtx_breakloop_isset(struct rxtx_desc *p);
@@ -74,6 +74,7 @@ const char *rxtx_get_ifname(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packet_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
+struct rxtx_ring *rxtx_get_ring(struct rxtx_desc *p, unsigned int idx);
 int rxtx_get_ring_count(struct rxtx_desc *p);
 const ring_set_t *rxtx_get_ring_set(struct rxtx_desc *p);
 const char *rxtx_get_savefile_template(struct rxtx_desc *p);
@@ -82,9 +83,24 @@ int rxtx_packet_count_reached(struct rxtx_desc *p);
 int rxtx_promiscuous_isset(struct rxtx_desc *p);
 int rxtx_verbose_isset(struct rxtx_desc *p);
 
-void rxtx_increment_initialized_ring_count(struct rxtx_desc *p);
+int rxtx_increment_initialized_ring_count(struct rxtx_desc *p);
 int rxtx_increment_packets_received(struct rxtx_desc *p);
-void rxtx_set_breakloop(struct rxtx_desc *p);
+int rxtx_set_breakloop(struct rxtx_desc *p);
 void rxtx_set_breakloop_global(void);
+int rxtx_set_direction(struct rxtx_desc *p, pcap_direction_t direction);
+int rxtx_set_fanout_group_id(struct rxtx_desc *p, int group_id);
+int rxtx_set_fanout_mode(struct rxtx_desc *p, int mode);
+int rxtx_set_ifindex(struct rxtx_desc *p, unsigned int ifindex);
+int rxtx_set_ifname(struct rxtx_desc *p, const char *ifname);
+int rxtx_set_packet_count(struct rxtx_desc *p, uintmax_t count);
+int rxtx_set_ring_count(struct rxtx_desc *p, unsigned int count);
+int rxtx_set_ring_set(struct rxtx_desc *p, const ring_set_t *set);
+int rxtx_set_savefile_template(struct rxtx_desc *p, const char *template);
+int rxtx_set_packet_buffered(struct rxtx_desc *p);
+int rxtx_set_promiscuous(struct rxtx_desc *p);
+void rxtx_set_verbose(struct rxtx_desc *p);
+int rxtx_unset_packet_buffered(struct rxtx_desc *p);
+int rxtx_unset_promiscuous(struct rxtx_desc *p);
+void rxtx_unset_verbose(struct rxtx_desc *p);
 
 #endif // _RXTX_H_

--- a/rxtx.h
+++ b/rxtx.h
@@ -76,6 +76,7 @@ uintmax_t rxtx_get_packet_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
 int rxtx_get_ring_count(struct rxtx_desc *p);
 const ring_set_t *rxtx_get_ring_set(struct rxtx_desc *p);
+const char *rxtx_get_savefile_template(struct rxtx_desc *p);
 int rxtx_packet_buffered_isset(struct rxtx_desc *p);
 int rxtx_packet_count_reached(struct rxtx_desc *p);
 int rxtx_promiscuous_isset(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -58,6 +58,7 @@ struct rxtx_desc {
   int               fanout_group_id;
   int               initialized_ring_count;
   int               breakloop;
+  char              *errbuf;
 };
 
 int rxtx_open(struct rxtx_desc *rtd, struct rxtx_args *args);

--- a/rxtx.h
+++ b/rxtx.h
@@ -74,6 +74,7 @@ const char *rxtx_get_ifname(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packet_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
+int rxtx_get_ring_count(struct rxtx_desc *p);
 int rxtx_packet_buffered_isset(struct rxtx_desc *p);
 int rxtx_packet_count_reached(struct rxtx_desc *p);
 int rxtx_promiscuous_isset(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -75,6 +75,7 @@ int rxtx_get_initialized_ring_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packet_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
 int rxtx_get_ring_count(struct rxtx_desc *p);
+const ring_set_t *rxtx_get_ring_set(struct rxtx_desc *p);
 int rxtx_packet_buffered_isset(struct rxtx_desc *p);
 int rxtx_packet_count_reached(struct rxtx_desc *p);
 int rxtx_promiscuous_isset(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -62,7 +62,7 @@ struct rxtx_desc {
 };
 
 int rxtx_open(struct rxtx_desc *rtd, struct rxtx_args *args);
-int rxtx_close(struct rxtx_desc *rtd);
+int rxtx_close(struct rxtx_desc *p);
 
 int rxtx_breakloop_isset(struct rxtx_desc *p);
 pcap_direction_t rxtx_get_direction(struct rxtx_desc *p);

--- a/rxtx.h
+++ b/rxtx.h
@@ -70,6 +70,7 @@ int rxtx_get_fanout_arg(struct rxtx_desc *p);
 int rxtx_get_fanout_group_id(struct rxtx_desc *p);
 int rxtx_get_fanout_mode(struct rxtx_desc *p);
 unsigned int rxtx_get_ifindex(struct rxtx_desc *p);
+const char *rxtx_get_ifname(struct rxtx_desc *p);
 int rxtx_get_initialized_ring_count(struct rxtx_desc *p);
 uintmax_t rxtx_get_packets_received(struct rxtx_desc *p);
 int rxtx_packet_buffered_isset(struct rxtx_desc *p);

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -277,6 +277,10 @@ void *rxtx_ring_loop(void *ring) {
       exit(EXIT_FAIL);
     }
 
+    if (length == 0) {
+      continue;
+    }
+
     status = rxtx_increment_packets_received(p->rtd);
     if (status == RXTX_ERROR) {
       fprintf(stderr, "%s: %s\n", program_basename, p->errbuf);
@@ -316,50 +320,34 @@ int rxtx_ring_next_packet(struct rxtx_ring *p, struct pcap_pkthdr *header,
   unsigned int sll_len = sizeof(sll);
 
   int length = 0;
-  int n = 0;
   int status = 0;
 
-  while (!rxtx_breakloop_isset(p->rtd)) {
-    /*
-     * We don't want this function to block indefinitely when the only packets
-     * seen are in an unwanted direction. For now, we'll treat 10 consecutive
-     * in an unwanted direction as a timeout.
-     */
-    if (n >= 10) {
-      return RXTX_TIMEOUT;
-    }
+  length = recvfrom(p->fd, packet, PACKET_BUFFER_SIZE, 0,
+                                          (struct sockaddr *)&sll, &sll_len);
 
-    length = recvfrom(p->fd, packet, PACKET_BUFFER_SIZE, 0,
-                                            (struct sockaddr *)&sll, &sll_len);
-
-    if (length == -1) {
-      return RXTX_TIMEOUT;
-    }
-
-    n++;
-
-    if (rxtx_get_direction(p->rtd) == PCAP_D_OUT &&
-                                                packet_direction_is_rx(&sll)) {
-      continue;
-    }
-
-    if (rxtx_get_direction(p->rtd) == PCAP_D_IN &&
-                                                packet_direction_is_tx(&sll)) {
-      continue;
-    }
-
-    status = rxtx_stats_increment_packets_received(p->stats, INCREMENT_STEP);
-    if (status == RXTX_ERROR) {
-      return RXTX_ERROR;
-    }
-
-    header->caplen     = (bpf_u_int32)length;
-    header->len        = (bpf_u_int32)length;
-    header->ts.tv_sec  = time(NULL);
-    header->ts.tv_usec = 0;
-
-    break;
+  if (length == -1) {
+    return RXTX_TIMEOUT;
   }
+
+  if (rxtx_get_direction(p->rtd) == PCAP_D_OUT &&
+                                                packet_direction_is_rx(&sll)) {
+    return 0;
+  }
+
+  if (rxtx_get_direction(p->rtd) == PCAP_D_IN &&
+                                                packet_direction_is_tx(&sll)) {
+    return 0;
+  }
+
+  status = rxtx_stats_increment_packets_received(p->stats, INCREMENT_STEP);
+  if (status == RXTX_ERROR) {
+    return RXTX_ERROR;
+  }
+
+  header->caplen     = (bpf_u_int32)length;
+  header->len        = (bpf_u_int32)length;
+  header->ts.tv_sec  = time(NULL);
+  header->ts.tv_usec = 0;
 
   return length;
 }

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -43,6 +43,7 @@
 #include <errno.h>   // for errno
 #include <pcap.h>    // for bpf_u_int32, PCAP_D_IN, PCAP_D_OUT, pcap_pkthdr
 #include <pthread.h> // for pthread_self()
+#include <sched.h>   // for sched_getcpu()
 #include <stdio.h>   // for asprintf(), fprintf(), NULL, stderr
 #include <stdlib.h>  // for calloc(), exit(), free()
 #include <string.h>  // for memset(), strcmp(), strdup(), strerror()

--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -48,8 +48,6 @@
 #include <string.h>  // for memset(), strcmp(), strdup(), strerror()
 #include <time.h>    // for time()
 
-#define EXIT_FAIL 1
-
 #define INCREMENT_STEP 1
 
 #define PACKET_BUFFER_SIZE 65535
@@ -273,8 +271,7 @@ void *rxtx_ring_loop(void *ring) {
     }
 
     if (status == RXTX_ERROR) {
-      fprintf(stderr, "%s: %s\n", program_basename, p->errbuf);
-      exit(EXIT_FAIL);
+      return (void *)RXTX_ERROR;
     }
 
     if (length == 0) {
@@ -283,8 +280,7 @@ void *rxtx_ring_loop(void *ring) {
 
     status = rxtx_increment_packets_received(p->rtd);
     if (status == RXTX_ERROR) {
-      fprintf(stderr, "%s: %s\n", program_basename, p->errbuf);
-      exit(EXIT_FAIL);
+      return (void *)RXTX_ERROR;
     }
 
     if (p->savefile) {
@@ -292,11 +288,11 @@ void *rxtx_ring_loop(void *ring) {
                                            rxtx_packet_buffered_isset(p->rtd));
 
       if (status == RXTX_ERROR) {
-        fprintf(stderr, "%s: %s\n", program_basename, p->errbuf);
-        exit(EXIT_FAIL);
+        return (void *)RXTX_ERROR;
       }
     }
   }
+
   return NULL;
 }
 

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -477,7 +477,11 @@ int main(int argc, char **argv) {
   fprintf(out, "%ju packets captured total.\n",
                                               rxtx_get_packets_received(&rtd));
 
-  rxtx_close(&rtd);
+  status = rxtx_close(&rtd);
+  if (status == RXTX_ERROR) {
+    fprintf(stderr, "%s: %s\n", program_basename, rtd.errbuf);
+    return EXIT_FAIL;
+  }
 
   return EXIT_OK;
 }

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -107,7 +107,20 @@ static void usage_short(void) {
 /* ========================================================================= */
 int main(int argc, char **argv) {
   program_basename = basename(argv[0]);
-  int i;
+
+  int c = 0;
+  int i = 0;
+  int worker_count = 0;
+
+  bool help = false;
+
+  char *badopt = NULL;
+  char *cpu_list = NULL;
+  char *cpu_mask = NULL;
+  char *endptr = NULL;
+
+  FILE *out = stdout;
+
   struct rxtx_args args;
   memset(&args, 0, sizeof(args));
 
@@ -141,13 +154,6 @@ int main(int argc, char **argv) {
   if (strcmp(program_basename, "txcpu") == 0) {
     args.direction = PCAP_D_OUT;
   }
-
-  int c;
-  char *badopt = NULL;
-  char *cpu_list = NULL;
-  char *cpu_mask = NULL;
-  char *endptr = NULL;
-  bool help = false;
 
   /*
    * optstring must start with ":" so ':' is returned for a missing option
@@ -312,7 +318,7 @@ int main(int argc, char **argv) {
     }
   }
 
-  int worker_count = 0;
+  worker_count = 0;
   for_each_ring_in_size(i, args.ring_count) {
     if (RING_ISSET(i, &(args.ring_set))) {
       worker_count++;
@@ -410,7 +416,7 @@ int main(int argc, char **argv) {
    * This loop joins our threads and prints the per-ring, in this case per-cpu,
    * results.
    */
-  FILE *out = stdout;
+  out = stdout;
   if (args.savefile_template && strcmp(args.savefile_template, "-") == 0) {
     out = stderr;
   }

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -466,7 +466,8 @@ int main(int argc, char **argv) {
    * This loop prints our per-ring, in this case per-cpu, results.
    */
   out = stdout;
-  if (args.savefile_template && strcmp(args.savefile_template, "-") == 0) {
+  if (rxtx_get_savefile_template(&rtd) &&
+                          strcmp(rxtx_get_savefile_template(&rtd), "-") == 0) {
     out = stderr;
   }
   for_each_set_ring(i, &rtd) {

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -405,7 +405,7 @@ int main(int argc, char **argv) {
    * receive packets for that processor.
    */
   cpu_set_t cpu_set;
-  pthread_t threads[args.ring_count];
+  pthread_t threads[rxtx_get_ring_count(&rtd)];
   pthread_attr_t attr;
   pthread_attr_init(&attr);
 
@@ -424,8 +424,8 @@ int main(int argc, char **argv) {
 
   void *vpstatus = NULL;
 
-  int joined[args.ring_count];
-  memset(joined, 0, sizeof(int) * args.ring_count);
+  int joined[rxtx_get_ring_count(&rtd)];
+  memset(joined, 0, sizeof(int) * rxtx_get_ring_count(&rtd));
 
   while (1) {
     ebusy = 0;

--- a/rxtxcpu.c
+++ b/rxtxcpu.c
@@ -12,11 +12,19 @@
                        //     parse_cpu_mask()
 #include "ring_set.h"  // for for_each_ring_in_size(), RING_CLR(),
                        //     RING_COUNT(), RING_ISSET(), RING_SET()
-#include "rxtx.h"      // for for_each_set_ring(), program_basename, rxtx_args,
-                       //     rxtx_desc, rxtx_close(),
-                       //     rxtx_get_packets_received(), rxtx_open()
-#include "rxtx_error.h" // for RXTX_ERROR
-#include "rxtx_ring.h" // for rxtx_ring_get_packets_received(),
+#include "rxtx.h"      // for for_each_ring(), for_each_set_ring(),
+                       //     program_basename, rxtx_activate(), rxtx_close(),
+                       //     rxtx_desc, rxtx_get_packets_received(),
+                       //     rxtx_get_ring(), rxtx_get_ring_count(),
+                       //     rxtx_get_savefile_template(), rxtx_init(),
+                       //     rxtx_set_direction(), rxtx_set_fanout_mode(),
+                       //     rxtx_set_ifname(), rxtx_set_packet_buffered(),
+                       //     rxtx_set_promiscuous(), rxtx_set_ring_count(),
+                       //     rxtx_set_ring_set(),
+                       //     rxtx_set_savefile_template(), rxtx_set_verbose(),
+                       //     rxtx_verbose_isset()
+#include "rxtx_error.h" // for RXTX_ERRBUF_SIZE, RXTX_ERROR
+#include "rxtx_ring.h" // for rxtx_ring, rxtx_ring_get_packets_received(),
                        //     rxtx_ring_loop()
 #include "sig.h"       // for setup_signals()
 
@@ -113,6 +121,7 @@ int main(int argc, char **argv) {
   program_basename = basename(argv[0]);
 
   int c = 0;
+  int cpus = 0;
   int i = 0;
   int status = 0;
   int worker_count = 0;
@@ -126,8 +135,12 @@ int main(int argc, char **argv) {
 
   FILE *out = stdout;
 
-  struct rxtx_args args;
-  memset(&args, 0, sizeof(args));
+  char errbuf[RXTX_ERRBUF_SIZE] = "";
+
+  struct rxtx_desc rtd;
+  rxtx_init(&rtd, errbuf);
+
+  struct rxtx_ring* ring;
 
   /*
    * Per packet(7), "PACKET_FANOUT_CPU selects the socket based on the CPU that
@@ -143,22 +156,32 @@ int main(int argc, char **argv) {
    * need one socket per processor added to the fanout group in processor id
    * order.
    *
-   * rxtx_open() will handle the ordering, we just need to set the fanout mode.
+   * rxtx_activate() will handle the ordering, we just need to set the fanout
+   * mode.
    */
-  args.fanout_mode = PACKET_FANOUT_CPU;
+  status = rxtx_set_fanout_mode(&rtd, PACKET_FANOUT_CPU);
+  if (status == RXTX_ERROR) {
+    fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+    return EXIT_FAIL;
+  }
 
   /*
    * direction default is based on the invocation.
    */
-  args.direction = PCAP_D_INOUT;
-
   if (strcmp(program_basename, "rxcpu") == 0) {
-    args.direction = PCAP_D_IN;
+    status = rxtx_set_direction(&rtd, PCAP_D_IN);
+  } else if (strcmp(program_basename, "txcpu") == 0) {
+    status = rxtx_set_direction(&rtd, PCAP_D_OUT);
+  } else {
+    status = rxtx_set_direction(&rtd, PCAP_D_INOUT);
+  }
+  if (status == RXTX_ERROR) {
+    fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+    return EXIT_FAIL;
   }
 
-  if (strcmp(program_basename, "txcpu") == 0) {
-    args.direction = PCAP_D_OUT;
-  }
+  ring_set_t ring_set;
+  RING_ZERO(&ring_set);
 
   /*
    * optstring must start with ":" so ':' is returned for a missing option
@@ -169,7 +192,12 @@ int main(int argc, char **argv) {
                                                                        != -1) {
     switch (c) {
       case 'c':
-        args.packet_count = strtoumax(optarg, &endptr, OPTION_COUNT_BASE);
+        status = rxtx_set_packet_count(&rtd, strtoumax(optarg, &endptr,
+                                                           OPTION_COUNT_BASE));
+        if (status == RXTX_ERROR) {
+          fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+          return EXIT_FAIL;
+        }
         if (*endptr) {
           fprintf(stderr, "%s: Invalid count '%s'.\n", program_basename,
                                                                        optarg);
@@ -180,16 +208,20 @@ int main(int argc, char **argv) {
 
       case 'd':
         if (strcmp(optarg, "rx") == 0) {
-          args.direction = PCAP_D_IN;
+          status = rxtx_set_direction(&rtd, PCAP_D_IN);
         } else if (strcmp(optarg, "tx") == 0) {
-          args.direction = PCAP_D_OUT;
+          status = rxtx_set_direction(&rtd, PCAP_D_OUT);
         } else if (strcmp(optarg, "rxtx") == 0) {
-          args.direction = PCAP_D_INOUT;
+          status = rxtx_set_direction(&rtd, PCAP_D_INOUT);
         } else {
           fprintf(stderr, "%s: Invalid direction '%s'.\n", program_basename,
                                                                        optarg);
           usage_short();
           return EXIT_FAIL_OPTION;
+        }
+        if (status == RXTX_ERROR) {
+          fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+          return EXIT_FAIL;
         }
         break;
 
@@ -199,7 +231,7 @@ int main(int argc, char **argv) {
 
       case 'l':
         cpu_list = optarg;
-        if (parse_cpu_list(optarg, &(args.ring_set))) {
+        if (parse_cpu_list(optarg, &ring_set)) {
           fprintf(stderr, "%s: Invalid cpu list '%s'.\n", program_basename,
                                                                        optarg);
           usage_short();
@@ -209,7 +241,7 @@ int main(int argc, char **argv) {
 
       case 'm':
         cpu_mask = optarg;
-        if (parse_cpu_mask(optarg, &(args.ring_set))) {
+        if (parse_cpu_mask(optarg, &ring_set)) {
           fprintf(stderr, "%s: Invalid cpu mask '%s'.\n", program_basename,
                                                                        optarg);
           usage_short();
@@ -218,15 +250,23 @@ int main(int argc, char **argv) {
         break;
 
       case 'p':
-        args.promiscuous = true;
+        status = rxtx_set_promiscuous(&rtd);
+        if (status == RXTX_ERROR) {
+          fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+          return EXIT_FAIL;
+        }
         break;
 
       case 'U':
-        args.packet_buffered = true;
+        status = rxtx_set_packet_buffered(&rtd);
+        if (status == RXTX_ERROR) {
+          fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+          return EXIT_FAIL;
+        }
         break;
 
       case 'v':
-        args.verbose = true;
+        rxtx_set_verbose(&rtd);
         break;
 
       case 'V':
@@ -234,7 +274,11 @@ int main(int argc, char **argv) {
         return EXIT_OK;
 
       case 'w':
-        args.savefile_template = optarg;
+        status = rxtx_set_savefile_template(&rtd, optarg);
+        if (status == RXTX_ERROR) {
+          fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+          return EXIT_FAIL;
+        }
         break;
 
       case ':':  /* missing option argument */
@@ -307,25 +351,31 @@ int main(int argc, char **argv) {
   /*
    * We need to know how many processors are configured.
    */
-  args.ring_count = sysconf(_SC_NPROCESSORS_CONF);
-  if (args.ring_count <= 0) {
+  cpus = sysconf(_SC_NPROCESSORS_CONF);
+  if (cpus <= 0) {
     fprintf(stderr, "%s: Failed to get processor count.\n", program_basename);
     return EXIT_FAIL;
   }
 
-  if (args.verbose) {
-    fprintf(stderr, "Found '%d' processors.\n", args.ring_count);
+  status = rxtx_set_ring_count(&rtd, cpus);
+  if (status == RXTX_ERROR) {
+    fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+    return EXIT_FAIL;
   }
 
-  if (RING_COUNT(&(args.ring_set)) == 0) {
-    for_each_ring_in_size(i, args.ring_count) {
-      RING_SET(i, &(args.ring_set));
+  if (rxtx_verbose_isset(&rtd)) {
+    fprintf(stderr, "Found '%d' processors.\n", rxtx_get_ring_count(&rtd));
+  }
+
+  if (RING_COUNT(&ring_set) == 0) {
+    for_each_ring(i, &rtd) {
+      RING_SET(i, &ring_set);
     }
   }
 
   worker_count = 0;
-  for_each_ring_in_size(i, args.ring_count) {
-    if (RING_ISSET(i, &(args.ring_set))) {
+  for_each_ring(i, &rtd) {
+    if (RING_ISSET(i, &ring_set)) {
       worker_count++;
     }
   }
@@ -342,11 +392,11 @@ int main(int argc, char **argv) {
     return EXIT_FAIL_OPTION;
   }
 
-  if (CPU_COUNT(&online_cpu_set) != args.ring_count) {
-    for_each_ring_in_size(i, args.ring_count) {
+  if (CPU_COUNT(&online_cpu_set) != rxtx_get_ring_count(&rtd)) {
+    for_each_ring(i, &rtd) {
       if (!CPU_ISSET(i, &online_cpu_set)) {
-        RING_CLR(i, &(args.ring_set));
-        if (args.verbose) {
+        RING_CLR(i, &ring_set);
+        if (rxtx_verbose_isset(&rtd)) {
           fprintf(stderr, "Skipping cpu '%d' since it is offline.\n", i);
         }
       }
@@ -354,8 +404,8 @@ int main(int argc, char **argv) {
   }
 
   worker_count = 0;
-  for_each_ring_in_size(i, args.ring_count) {
-    if (RING_ISSET(i, &(args.ring_set))) {
+  for_each_ring(i, &rtd) {
+    if (RING_ISSET(i, &ring_set)) {
       worker_count++;
     }
   }
@@ -366,12 +416,19 @@ int main(int argc, char **argv) {
     return EXIT_FAIL_OPTION;
   }
 
-  if (args.savefile_template && strcmp(args.savefile_template, "-") == 0 &&
-                                           RING_COUNT(&(args.ring_set)) != 1) {
+  if (rxtx_get_savefile_template(&rtd) &&
+                          strcmp(rxtx_get_savefile_template(&rtd), "-") == 0 &&
+                                                  RING_COUNT(&ring_set) != 1) {
     fprintf(stderr, "%s: Write file '-' (stdout) is only permitted when"
                             " capturing on a single cpu.\n", program_basename);
     usage_short();
     return EXIT_FAIL_OPTION;
+  }
+
+  status = rxtx_set_ring_set(&rtd, &ring_set);
+  if (status == RXTX_ERROR) {
+    fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+    return EXIT_FAIL;
   }
 
   if ((optind + 1) < argc) {
@@ -388,11 +445,18 @@ int main(int argc, char **argv) {
   }
 
   if (optind != argc) {
-    args.ifname = argv[optind];
+    status = rxtx_set_ifname(&rtd, argv[optind]);
+    if (status == RXTX_ERROR) {
+      fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+      return EXIT_FAIL;
+    }
   }
 
-  struct rxtx_desc rtd;
-  rxtx_open(&rtd, &args);
+  status = rxtx_activate(&rtd);
+  if (status == RXTX_ERROR) {
+    fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+    return EXIT_FAIL;
+  }
 
   /*
    * Setup our signal handlers before spinning up threads.
@@ -413,8 +477,13 @@ int main(int argc, char **argv) {
     CPU_ZERO(&cpu_set);
     CPU_SET(i, &cpu_set);
     pthread_attr_setaffinity_np(&attr, sizeof(cpu_set), &cpu_set);
-    pthread_create(&threads[i], &attr, rxtx_ring_loop,
-                                                      (void *)&(rtd.rings[i]));
+
+    ring = rxtx_get_ring(&rtd, (unsigned int)i);
+    if (!ring) {
+      fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+      return EXIT_FAIL;
+    }
+    pthread_create(&threads[i], &attr, rxtx_ring_loop, (void *)ring);
   }
 
   /*
@@ -447,7 +516,7 @@ int main(int argc, char **argv) {
 
         joined[i] = 1;
         if ((intptr_t)vpstatus == (intptr_t)RXTX_ERROR) {
-          fprintf(stderr, "%s: %s\n", program_basename, rtd.errbuf);
+          fprintf(stderr, "%s: %s\n", program_basename, errbuf);
           return EXIT_FAIL;
         }
       }
@@ -470,9 +539,16 @@ int main(int argc, char **argv) {
                           strcmp(rxtx_get_savefile_template(&rtd), "-") == 0) {
     out = stderr;
   }
+
   for_each_set_ring(i, &rtd) {
+    ring = rxtx_get_ring(&rtd, (unsigned int)i);
+    if (!ring) {
+      fprintf(stderr, "%s: %s\n", program_basename, errbuf);
+      return EXIT_FAIL;
+    }
+
     fprintf(out, "%ju packets captured on cpu%d.\n",
-                           rxtx_ring_get_packets_received(&(rtd.rings[i])), i);
+                                      rxtx_ring_get_packets_received(ring), i);
   }
 
   fprintf(out, "%ju packets captured total.\n",
@@ -480,7 +556,7 @@ int main(int argc, char **argv) {
 
   status = rxtx_close(&rtd);
   if (status == RXTX_ERROR) {
-    fprintf(stderr, "%s: %s\n", program_basename, rtd.errbuf);
+    fprintf(stderr, "%s: %s\n", program_basename, errbuf);
     return EXIT_FAIL;
   }
 


### PR DESCRIPTION
Improvements and reorganization 2.

* Have rxtx_ring_next_packet() return length 0 for packets in an unwanted direction.
* Leverage pthread_tryjoin_np() so main() notices a return from any rxtx_ring_loop().
* Add several getters.
* Move to rxtx_init(), rxtx_set_*(), rxtx_activate() interface.
* All previous exits() in rxtx.c are now returns.