### PR TITLE
Free filename even when rxtx_savefile_open() returns RXTX_ERROR.

### DIFF
--- a/rxtx_ring.c
+++ b/rxtx_ring.c
@@ -407,11 +407,10 @@ int rxtx_ring_savefile_open(struct rxtx_ring *p, const char *template) {
   }
 
   status = rxtx_savefile_open(p->savefile, filename, p->errbuf);
+  free(filename);
   if (status == RXTX_ERROR) {
     return RXTX_ERROR;
   }
-
-  free(filename);
 
   return 0;
 }


### PR DESCRIPTION
I was testing out gcc's static analysis and it found a leak. This is pretty minor since an RXTX_ERROR at that point in the code will result in rxtx{cpu,numa,queue} exiting, but still well worth fixing.

I did the following to run the static analysis:
1. Used gcc v11.1.0.
```
[vagrant@localhost ~]$ docker pull gcc:11.1.0
...
[vagrant@localhost ~]$ docker run -it gcc:11.1.0
...
root@1f6fccc648cc:/# gcc --version
gcc (GCC) 11.1.0
...
```
2. Cloned the project.
```
root@1f6fccc648cc:/# git clone https://github.com/stackpath/rxtxcpu
...
root@1f6fccc648cc:/# cd rxtxcpu/
root@1f6fccc648cc:/rxtxcpu# 
```
3. Added `-fanalyzer` to CFLAGS.
```
root@1f6fccc648cc:/rxtxcpu# git diff
diff --git a/Makefile b/Makefile
index 6f229e0..c2bde61 100644
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC = gcc
-CFLAGS = -Wall -Wcast-align -Wcast-qual -Wimplicit -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow
+CFLAGS = -Wall -Wcast-align -Wcast-qual -Wimplicit -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow -fanalyzer
 PREFIX = /usr/local
 
 include VERSION
```
4. Installed the build requires.
```
root@1f6fccc648cc:/rxtxcpu# apt-get update
...
root@1f6fccc648cc:/rxtxcpu# apt-get install libpcap-dev
...
```
5. Ran make.
```
root@1f6fccc648cc:/rxtxcpu# make
...
gcc -Wall -Wcast-align -Wcast-qual -Wimplicit -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow -fanalyzer  -c -o rxtx_ring.o rxtx_ring.c
In function 'rxtx_ring_savefile_open':
rxtx_ring.c:409:12: warning: leak of 'strdup(template)' [CWE-401] [-Wanalyzer-malloc-leak]
  409 |   status = rxtx_savefile_open(p->savefile, filename, p->errbuf);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  'rxtx_ring_savefile_open': events 1-11
    |
    |  373 |   if (!template) {
    |      |      ^
    |      |      |
    |      |      (1) following 'false' branch (when 'template' is non-NULL)...
    |......
    |  378 |   p->savefile = calloc(1, sizeof(*p->savefile));
    |      |                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |                 |
    |      |                 (2) ...to here
    |  379 |   if (!p->savefile) {
    |      |      ~
    |      |      |
    |      |      (3) following 'false' branch...
    |......
    |  384 |   if (strcmp(template, "-") == 0) {
    |      |      ~~~~~~~~~~~~~~~~~~~~~~
    |      |      ||
    |      |      |(4) ...to here
    |      |      (5) following 'true' branch (when the strings are equal)...
    |  385 |     filename = strdup(template);
    |      |                ~~~~~~~~~~~~~~~~
    |      |                |
    |      |                (6) ...to here
    |      |                (7) allocated here
    |  386 |     if (!filename) {
    |      |        ~
    |      |        |
    |      |        (8) assuming 'filename' is non-NULL
    |      |        (9) following 'false' branch...
    |......
    |  409 |   status = rxtx_savefile_open(p->savefile, filename, p->errbuf);
    |      |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |            |
    |      |            (10) ...to here
    |  410 |   if (status == RXTX_ERROR) {
    |      |      ~
    |      |      |
    |      |      (11) following 'true' branch (when 'status == -1')...
    |
  'rxtx_ring_savefile_open': event 12
    |
    |rxtx_error.h:17:22:
    |   17 | #define RXTX_ERROR   -1
    |      |                      ^
    |      |                      |
    |      |                      (12) ...to here
rxtx_ring.c:411:12: note: in expansion of macro 'RXTX_ERROR'
    |  411 |     return RXTX_ERROR;
    |      |            ^~~~~~~~~~
    |
  'rxtx_ring_savefile_open': event 13
    |
    |  409 |   status = rxtx_savefile_open(p->savefile, filename, p->errbuf);
    |      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    |      |            |
    |      |            (13) 'strdup(template)' leaks here; was allocated at (7)
    |
...
```