### PR TITLE
Free memory used in parse_cpu_list() on RETURN_BAD.

### DIFF
--- a/cpu.c
+++ b/cpu.c
@@ -157,6 +157,7 @@ int parse_cpu_list(char *cpu_list, cpu_set_t *cpu_set) {
      *       where last equals first, so we will too).
      */
     if (save[0] != '-' || *endptr || last < first) {
+      free(tofree);
       return RETURN_BAD;
     }
 


### PR DESCRIPTION
I was testing out clang's static analysis and it found a leak. This is pretty minor since a RETURN_BAD at that point in the code will result in rxtx{cpu,numa,queue} exiting, but still well worth fixing.

Installation.
```
[vagrant@localhost rxtxcpu]$ sudo yum install llvm-toolset-7.0-clang-{analyzer,tools-extra}
...
```
Running `scan-build`.
```
[vagrant@localhost rxtxcpu]$ scan-build make
scan-build: Using '/opt/rh/llvm-toolset-7.0/root/usr/bin/clang-7' for static analysis
/opt/rh/llvm-toolset-7.0/root/usr/bin/../libexec/ccc-analyzer -Wall -Wcast-align -Wcast-qual -Wimplicit -Wpointer-arith -Wredundant-decls -Wreturn-type -Wshadow -std=c99 -c -o cpu.o cpu.c
cpu.c:160:14: warning: Potential leak of memory pointed to by 'range'
      return RETURN_BAD;
             ^~~~~~~~~~
cpu.c:20:21: note: expanded from macro 'RETURN_BAD'
#define RETURN_BAD -1
                    ^
1 warning generated.
...
```
Running `clang-tidy` gives more information.
```
[vagrant@localhost rxtxcpu]$ clang-tidy cpu.c 
Error while trying to load a compilation database:
Could not auto-detect compilation database for file "cpu.c"
No compilation database found in /home/vagrant/rxtxcpu or any parent directory
fixed-compilation-database: Error while opening fixed database: No such file or directory
json-compilation-database: Error while opening JSON database: No such file or directory
Running without flags.
1 warning generated.
/home/vagrant/rxtxcpu/cpu.c:160:14: warning: Potential leak of memory pointed to by 'range' [clang-analyzer-unix.Malloc]
      return RETURN_BAD;
             ^
/home/vagrant/rxtxcpu/cpu.c:20:21: note: expanded from macro 'RETURN_BAD'
#define RETURN_BAD -1
                    ^
/home/vagrant/rxtxcpu/cpu.c:91:7: note: Assuming the condition is false
  if (status == -1) {
      ^
/home/vagrant/rxtxcpu/cpu.c:91:3: note: Taking false branch
  if (status == -1) {
  ^
/home/vagrant/rxtxcpu/cpu.c:96:7: note: Assuming 'f' is non-null
  if (!f || feof(f) || !fgets(cpu_list, sizeof(cpu_list), f)) {
      ^
/home/vagrant/rxtxcpu/cpu.c:96:7: note: Left side of '||' is false
/home/vagrant/rxtxcpu/cpu.c:96:13: note: Assuming the condition is false
  if (!f || feof(f) || !fgets(cpu_list, sizeof(cpu_list), f)) {
            ^
/home/vagrant/rxtxcpu/cpu.c:96:7: note: Left side of '||' is false
  if (!f || feof(f) || !fgets(cpu_list, sizeof(cpu_list), f)) {
      ^
/home/vagrant/rxtxcpu/cpu.c:96:24: note: Assuming the condition is false
  if (!f || feof(f) || !fgets(cpu_list, sizeof(cpu_list), f)) {
                       ^
/home/vagrant/rxtxcpu/cpu.c:96:3: note: Taking false branch
  if (!f || feof(f) || !fgets(cpu_list, sizeof(cpu_list), f)) {
  ^
/home/vagrant/rxtxcpu/cpu.c:105:3: note: Calling 'parse_cpu_list'
  parse_cpu_list(cpu_list, cpu_set);
  ^
/home/vagrant/rxtxcpu/cpu.c:128:7: note: Assuming the condition is false
  if (strlen(cpu_list) == 0) {
      ^
/home/vagrant/rxtxcpu/cpu.c:128:3: note: Taking false branch
  if (strlen(cpu_list) == 0) {
  ^
/home/vagrant/rxtxcpu/cpu.c:135:21: note: Memory is allocated
  tofree = string = strdup(cpu_list);
                    ^
/home/vagrant/rxtxcpu/cpu.c:137:10: note: Assuming the condition is true
  while ((range = strsep(&string, ",")) != NULL) {
         ^
/home/vagrant/rxtxcpu/cpu.c:137:3: note: Loop condition is true.  Entering loop body
  while ((range = strsep(&string, ",")) != NULL) {
  ^
/home/vagrant/rxtxcpu/cpu.c:143:9: note: Assuming the condition is false
    if (!*endptr) {
        ^
/home/vagrant/rxtxcpu/cpu.c:143:5: note: Taking false branch
    if (!*endptr) {
    ^
/home/vagrant/rxtxcpu/cpu.c:159:9: note: Assuming the condition is true
    if (save[0] != '-' || *endptr || last < first) {
        ^
/home/vagrant/rxtxcpu/cpu.c:159:24: note: Left side of '||' is true
    if (save[0] != '-' || *endptr || last < first) {
                       ^
/home/vagrant/rxtxcpu/cpu.c:160:14: note: Potential leak of memory pointed to by 'range'
      return RETURN_BAD;
             ^
/home/vagrant/rxtxcpu/cpu.c:20:21: note: expanded from macro 'RETURN_BAD'
#define RETURN_BAD -1
                    ^
```